### PR TITLE
Add public user activity page with linking

### DIFF
--- a/src/components/RecipeHeader.tsx
+++ b/src/components/RecipeHeader.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import UserLink from './UserLink';
 import { formatDate } from '../utils/utils';
 import { ExtendedRecipe } from '../types';
 
@@ -35,7 +36,10 @@ const RecipeHeader = ({ recipeData }: RecipeHeaderProps) => (
                     />
                 </div>
                 <div>
-                    <span className="text-gray-700 text-lg">By {recipeData.owner.name}</span> {/* Owner's name */}
+                    <span className="text-gray-700 text-lg">By <UserLink
+                        userId={recipeData.owner._id}
+                        name={recipeData.owner.name}
+                    /></span>
                     <p className="text-sm text-gray-500">{formatDate(recipeData.createdAt)}</p>
                 </div>
             </div>

--- a/src/components/Recipe_Display/Dialog.tsx
+++ b/src/components/Recipe_Display/Dialog.tsx
@@ -6,6 +6,7 @@ import useActionPopover from '../Hooks/useActionPopover';
 import RecipeCard from '../RecipeCard';
 import Loading from '../Loading';
 import { ActionPopover } from './ActionPopover';
+import UserLink from '../UserLink';
 import { formatDate } from '../../utils/utils';
 import { ExtendedRecipe } from '../../types';
 
@@ -86,7 +87,12 @@ export default function RecipeDisplayModal({ isOpen, close, recipe, removeRecipe
                                                 height={25}
                                             />
                                             <div className="ml-4">
-                                                <p className="text-lg font-semibold text-gray-900">{recipe.owner.name}</p>
+                                                <p className="text-lg font-semibold text-gray-900">
+                                                    <UserLink
+                                                        userId={recipe.owner._id}
+                                                        name={recipe.owner.name}
+                                                    />
+                                                </p>
                                                 <p className="text-sm text-gray-500">{formatDate(recipe.createdAt)}</p>
                                             </div>
                                         </div>

--- a/src/components/UserLink.tsx
+++ b/src/components/UserLink.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+
+interface UserLinkProps {
+    userId: string;
+    name: string;
+}
+
+export default function UserLink({ userId, name }: UserLinkProps) {
+    const router = useRouter();
+
+    const handleClick = () => {
+        router.push(`/UserActivity?userId=${userId}`);
+    };
+
+    return (
+        <span
+            onClick={handleClick}
+            className="text-gray-600 hover:text-gray-800 hover:underline cursor-pointer"
+        >
+            {name}
+        </span>
+    );
+}

--- a/src/pages/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail.tsx
@@ -6,6 +6,7 @@ import useActionPopover from "../components/Hooks/useActionPopover";
 import { useRecipeData } from "../components/Hooks/useRecipeData";
 import { ActionPopover } from "../components/Recipe_Display/ActionPopover";
 import RecipeHeader from "../components/RecipeHeader";
+import UserLink from "../components/UserLink";
 import Loading from "../components/Loading";
 import ErrorPage from "./auth/error";
 import { call_api } from "../utils/utils";
@@ -185,7 +186,7 @@ export default function RecipeDetail() {
                                             className="rounded-full" // Make the image circular
                                         />
                                     </div>
-                                    <span className="text-gray-700">{user.name}</span> {/* User's name */}
+                                    <span className="text-gray-700"><UserLink name={user.name} userId={user._id}/></span>
                                 </div>
                             ))}
                         </div>

--- a/src/pages/UserActivity.tsx
+++ b/src/pages/UserActivity.tsx
@@ -1,0 +1,148 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Loading from '../components/Loading';
+import ErrorPage from './auth/error';
+import { ExtendedRecipe } from '../types';
+import { call_api } from '../utils/utils';
+import ViewRecipes from '../components/Recipe_Display/ViewRecipes';
+
+interface UserType {
+    name: string;
+    image: string;
+    joinedDate: string;
+}
+
+const initialUser: UserType = {
+    name: '',
+    image: '',
+    joinedDate: '',
+};
+
+export default function UserActivityPage() {
+    const router = useRouter();
+    const { userId } = router.query as { userId?: string };
+
+    const [user, setUser] = useState<UserType>(initialUser);
+    const [createdRecipes, setCreatedRecipes] = useState<ExtendedRecipe[]>([]);
+    const [likedRecipes, setLikedRecipes] = useState<ExtendedRecipe[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [activeTab, setActiveTab] = useState<'created' | 'liked'>('created');
+
+    useEffect(() => {
+        if (!userId) return;
+        const fetchData = async () => {
+            try {
+                setLoading(true);
+                const result = await call_api({ address: `/api/get-user-activity?userId=${userId}` });
+                if (result.error) {
+                    throw new Error(result.error);
+                }
+                setUser(result.user || initialUser);
+                setCreatedRecipes(result.createdRecipes || []);
+                setLikedRecipes(result.likedRecipes || []);
+                setLoading(false);
+            } catch (err: any) {
+                console.error(err);
+                setError(err.message || 'Failed to load user activity');
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [userId]);
+
+    const handleRecipeListUpdate = (updatedRecipe: ExtendedRecipe | null, deleteId?: string) => {
+        if (updatedRecipe) {
+            // Update a recipe
+            if (activeTab === 'created') {
+                setCreatedRecipes((prev) =>
+                    prev.map((recipe) => recipe._id === updatedRecipe._id ? updatedRecipe : recipe)
+                );
+            } else {
+                setLikedRecipes((prev) =>
+                    prev.map((recipe) => recipe._id === updatedRecipe._id ? updatedRecipe : recipe)
+                );
+            }
+        } else if (deleteId) {
+            // Delete a recipe
+            if (activeTab === 'created') {
+                setCreatedRecipes((prev) =>
+                    prev.filter((recipe) => recipe._id !== deleteId)
+                );
+            } else {
+                setLikedRecipes((prev) =>
+                    prev.filter((recipe) => recipe._id !== deleteId)
+                );
+            }
+        }
+    };
+
+    // Render the ErrorPage component if userId is not present
+    if (!userId) return <ErrorPage message="Invalid Recipe" />;
+    if (loading) return <Loading />;
+    if (error) return <ErrorPage message={error} />;
+
+    const recipesToShow = activeTab === 'created' ? createdRecipes : likedRecipes;
+
+    return (
+        <div className="min-h-screen bg-gray-100 p-4">
+            <div className="max-w-4xl mx-auto bg-white shadow-lg rounded-lg overflow-hidden p-6">
+                <div className="mb-6">
+                    {/* User Info */}
+                    <div className="flex flex-col items-center space-y-4 mb-6 mt-4">
+                        {user?.image && (
+                            <div className="relative w-16 h-16 rounded-full overflow-hidden">
+                                <Image
+                                    src={user.image}
+                                    alt={user.name}
+                                    fill
+                                    style={{ objectFit: 'cover' }}
+                                    className="rounded-full"
+                                />
+                            </div>
+                        )}
+                        <h1 className="text-2xl font-bold text-gray-800">{user?.name}</h1>
+                        {user?.joinedDate && (
+                            <p className="text-sm text-gray-500">
+                                Joined {new Date(user.joinedDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long' })}
+                            </p>
+                        )}
+                    </div>
+                    {/* Tabs */}
+                    <div className="flex justify-center space-x-4 mt-4 mb-6">
+                        <button
+                            className={`px-3 py-1.5 text-sm rounded-full font-semibold ${activeTab === 'created'
+                                    ? 'bg-green-500 text-white'
+                                    : 'bg-gray-200 text-gray-800'
+                                }`}
+                            onClick={() => setActiveTab('created')}
+                        >
+                            Created Recipes
+                        </button>
+                        <button
+                            className={`px-3 py-1.5 text-sm rounded-full font-semibold ${activeTab === 'liked'
+                                    ? 'bg-green-500 text-white'
+                                    : 'bg-gray-200 text-gray-800'
+                                }`}
+                            onClick={() => setActiveTab('liked')}
+                        >
+                            Liked Recipes
+                        </button>
+                    </div>
+                </div>
+
+
+            </div>
+            {/* Recipes List */}
+            {recipesToShow.length === 0 ? (
+                <div className="text-center text-gray-500 mt-10">
+                    {activeTab === 'created' ? 'No recipes created yet.' : 'No liked recipes yet.'}
+                </div>
+            ) : (
+                <ViewRecipes recipes={recipesToShow} handleRecipeListUpdate={handleRecipeListUpdate} />
+            )}
+        </div>
+    );
+}

--- a/src/pages/api/get-user-activity.ts
+++ b/src/pages/api/get-user-activity.ts
@@ -1,0 +1,46 @@
+// /pages/api/get-user-activity.ts
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { connectDB } from '../../lib/mongodb';
+import mongoose from 'mongoose';
+import Recipe from '../../models/recipe';
+import { apiMiddleware } from '../../lib/apiMiddleware';
+import { filterResults } from '../../utils/utils';
+import { ExtendedRecipe } from '../../types';
+
+/**
+ * API handler for fetching user activity (created and liked recipes).
+ * @param req - The Next.js API request object.
+ * @param res - The Next.js API response object.
+ * @param session - The user session from `apiMiddleware`.
+ */
+const handler = async (req: NextApiRequest, res: NextApiResponse, session: any) => {
+    const { userId } = req.query;
+
+    // validate query
+    if (!userId || typeof userId != 'string' || !mongoose.Types.ObjectId.isValid(userId)) {
+        return res.status(401).json({ error: 'Invalid user ID' });
+    }
+    try {
+        await connectDB();
+
+        const createdRecipes = await Recipe.find({ owner: userId })
+            .sort({ createdAt: -1 })
+            .lean() as unknown as ExtendedRecipe[];
+
+        const likedRecipes = await Recipe.find({ likedBy: userId })
+            .sort({ createdAt: -1 })
+            .lean() as unknown as ExtendedRecipe[];
+
+        return res.status(200).json({
+            createdRecipes: filterResults(createdRecipes, session.user.id),
+            likedRecipes: filterResults(likedRecipes, session.user.id),
+        });
+    } catch (error) {
+        console.error('Error fetching user activity:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+}
+
+// Apply middleware for authentication & allowed methods
+export default apiMiddleware(['GET'], handler);

--- a/src/pages/api/get-user-activity.ts
+++ b/src/pages/api/get-user-activity.ts
@@ -32,10 +32,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, session: any) 
         const joinedDate = new Date(new mongoose.Types.ObjectId(userId).getTimestamp());
 
         const createdRecipes = await Recipe.find({ owner: userId })
+            .populate(['owner', 'likedBy', 'comments.user'])
             .sort({ createdAt: -1 })
-            .lean() as unknown as ExtendedRecipe[];
+            .lean() as unknown as ExtendedRecipe[]
 
         const likedRecipes = await Recipe.find({ likedBy: userId })
+            .populate(['owner', 'likedBy', 'comments.user'])
             .sort({ createdAt: -1 })
             .lean() as unknown as ExtendedRecipe[];
 

--- a/tests/pages/UserActivity.test.tsx
+++ b/tests/pages/UserActivity.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import UserActivityPage from "../../src/pages/UserActivity";
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as apiCalls from "../../src/utils/utils";
+import { stubRecipeBatch } from "../stub";
+
+jest.mock("../../src/utils/utils", () => ({
+    ...jest.requireActual("../../src/utils/utils"),
+    call_api: jest.fn()
+}));
+
+const routerMock = {
+    query: { userId: '507f1f77bcf86cd799439011' },
+    push: jest.fn(),
+    events: {
+      on: jest.fn(),
+      off: jest.fn()
+    }
+  };
+  
+  jest.mock('next/router', () => ({
+    useRouter: () => routerMock,
+  }));
+  
+
+describe('The User Activity Page', () => {
+    let getUserActivityAPI: any;
+
+    beforeEach(() => {
+        getUserActivityAPI = jest.spyOn(apiCalls, 'call_api');
+        getUserActivityAPI.mockResolvedValue({
+            user: {
+                name: 'John Doe',
+                image: 'https://example.com/avatar.jpg',
+                joinedDate: new Date().toISOString()
+            },
+            createdRecipes: stubRecipeBatch,
+            likedRecipes: stubRecipeBatch
+        });
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('shall render user info', async () => {
+        render(<UserActivityPage />);
+        expect(await screen.findByText('John Doe')).toBeInTheDocument();
+        expect(await screen.findByText(/Joined/)).toBeInTheDocument();
+    });
+
+    it('shall display created recipes by default', async () => {
+        render(<UserActivityPage />);
+        expect(await screen.findByText('Recipe_1_name')).toBeInTheDocument();
+    });
+
+    it('shall switch to liked recipes on tab click', async () => {
+        render(<UserActivityPage />);
+        const likedTab = await screen.findByText('Liked Recipes');
+        fireEvent.click(likedTab);
+        expect(await screen.findByText('Recipe_1_name')).toBeInTheDocument(); // same stub for likedRecipes
+    });
+    
+
+    it('shall display empty states if no recipes', async () => {
+        getUserActivityAPI.mockClear();
+        getUserActivityAPI.mockResolvedValueOnce({
+            user: {
+                name: 'John Doe',
+                image: 'https://example.com/avatar.jpg',
+                joinedDate: new Date().toISOString()
+            },
+            createdRecipes: [],
+            likedRecipes: []
+        });
+
+        render(<UserActivityPage />);
+        expect(await screen.findByText('No recipes created yet.')).toBeInTheDocument();
+        const likedTab = await screen.findByText('Liked Recipes');
+        fireEvent.click(likedTab);
+        expect(await screen.findByText('No liked recipes yet.')).toBeInTheDocument();
+    });
+
+    it('shall show error if fetch fails', async () => {
+        getUserActivityAPI.mockRejectedValueOnce(new Error('Mocked API Error'));
+        render(<UserActivityPage />);
+        expect(await screen.findByText('Mocked API Error')).toBeInTheDocument();
+    });
+});

--- a/tests/pages/__snapshots__/ChatAssistant.test.tsx.snap
+++ b/tests/pages/__snapshots__/ChatAssistant.test.tsx.snap
@@ -31,9 +31,12 @@ exports[`The ChatAssistant Page shall successfully render a recipe 1`] = `
               class="text-gray-700 text-lg"
             >
               By 
-              user_1
+              <span
+                class="text-gray-600 hover:text-gray-800 hover:underline cursor-pointer"
+              >
+                user_1
+              </span>
             </span>
-             
             <p
               class="text-sm text-gray-500"
             >

--- a/tests/pages/__snapshots__/RecipeDetail.test.tsx.snap
+++ b/tests/pages/__snapshots__/RecipeDetail.test.tsx.snap
@@ -31,9 +31,12 @@ exports[`The Recipe Detail Page shall succesfully render a recipe 1`] = `
               class="text-gray-700 text-lg"
             >
               By 
-              user_1
+              <span
+                class="text-gray-600 hover:text-gray-800 hover:underline cursor-pointer"
+              >
+                user_1
+              </span>
             </span>
-             
             <p
               class="text-sm text-gray-500"
             >
@@ -333,9 +336,12 @@ exports[`The Recipe Detail Page shall succesfully render a recipe 1`] = `
               <span
                 class="text-gray-700"
               >
-                user_2
+                <span
+                  class="text-gray-600 hover:text-gray-800 hover:underline cursor-pointer"
+                >
+                  user_2
+                </span>
               </span>
-               
             </div>
           </div>
         </div>

--- a/tests/pages/api/get-user-activity.test.ts
+++ b/tests/pages/api/get-user-activity.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ */
+import getUserActivity from '../../../src/pages/api/get-user-activity';
+import Recipe from '../../../src/models/recipe';
+import User from '../../../src/models/user';
+import { mockRequestResponse } from '../../apiMocks';
+import { stubRecipeBatch, getServerSessionStub } from '../../stub';
+import * as nextAuth from 'next-auth';
+
+// Mock authOptions
+jest.mock("../../../src/pages/api/auth/[...nextauth]", () => ({
+  authOptions: {
+    adapter: {},
+    providers: [],
+    callbacks: {},
+  },
+}));
+
+// Mock next-auth
+jest.mock("next-auth/next");
+
+// Mock db connection
+jest.mock('../../../src/lib/mongodb', () => ({
+  connectDB: () => Promise.resolve()
+}));
+
+describe('Fetching user activity (created and liked recipes)', () => {
+  let getServerSessionSpy: any
+
+  beforeEach(() => {
+    getServerSessionSpy = jest.spyOn(nextAuth, 'getServerSession')
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('shall reject requests that do not use the GET method', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+    const { req, res } = mockRequestResponse('POST')
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(405)
+    expect(res._getData()).toEqual(JSON.stringify({ error: 'Method POST Not Allowed' }))
+    expect(res._getHeaders()).toEqual({ allow: ['GET'], 'content-type': 'application/json' })
+  })
+
+  it('shall not proceed if user is not logged in', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(null))
+    const { req, res } = mockRequestResponse()
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(401)
+    expect(res._getJSONData()).toEqual({ error: 'You must be logged in.' })
+  })
+
+  it('shall reject if userId is missing or invalid', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub));
+    const { req, res } = mockRequestResponse()
+    // No userId
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(401)
+    expect(res._getJSONData()).toEqual({ error: 'Invalid user ID' })
+  })
+  
+  it('shall return 404 if user not found', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub));
+    
+    User.findById = jest.fn().mockImplementation(() => ({
+      select: jest.fn().mockImplementation(() => ({
+        lean: jest.fn().mockResolvedValue(null) // Simulate user not found
+      })),
+    }));
+  
+    const { req, res } = mockRequestResponse()
+    req.query.userId = '507f1f77bcf86cd799439011';
+  
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(404)
+    expect(res._getJSONData()).toEqual({ error: 'User not found' })
+  })
+  
+  it('shall return the user info and recipes', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+    
+    User.findById = jest.fn().mockImplementation(() => ({
+      select: jest.fn().mockImplementation(() => ({
+        lean: jest.fn().mockResolvedValue({
+          name: 'John Doe',
+          image: 'https://example.com/avatar.jpg'
+        }),
+      })),
+    }));
+
+    Recipe.find = jest.fn().mockImplementation(() => ({
+      populate: jest.fn().mockImplementation(() => ({
+        sort: jest.fn().mockImplementation(() => ({
+          lean: jest.fn().mockResolvedValue(stubRecipeBatch)
+        }))
+      }))
+    }));
+
+    const { req, res } = mockRequestResponse()
+    req.query.userId = '507f1f77bcf86cd799439011'; // valid dummy ObjectId
+
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(200)
+    expect(res._getJSONData()).toMatchObject({
+      user: {
+        name: 'John Doe',
+        image: 'https://example.com/avatar.jpg',
+      },
+      createdRecipes: stubRecipeBatch,
+      likedRecipes: stubRecipeBatch
+    })
+  })
+
+  it('will respond with internal server error if fetching fails', async () => {
+    getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+
+    User.findById = jest.fn().mockImplementation(() => ({
+      select: jest.fn().mockImplementation(() => ({
+        lean: jest.fn().mockRejectedValue(new Error('Mocked rejection')),
+      })),
+    }));
+
+    const { req, res } = mockRequestResponse()
+    req.query.userId = '507f1f77bcf86cd799439011';
+
+    await getUserActivity(req, res)
+    expect(res.statusCode).toBe(500)
+    expect(res._getJSONData()).toEqual({ error: 'Internal server error' })
+  })
+
+});


### PR DESCRIPTION
## Summary
This PR adds a public-facing user activity page where logged-in users can view another user's created and liked recipes.

- Created `/api/get-user-activity` endpoint with populated owner and likedBy fields
- Built `UserActivity.tsx` to display user info (name, profile image, joined date) and tabs for created/liked recipes
- Integrated `UserLink` component to make usernames clickable across the app
- Added basic tests for:
  - Successful API behavior
  - UserActivityPage rendering and tab switching
  - Error handling and empty states
- Deferred direct isolated testing of handleRecipeListUpdate for future cleanup

## Notes
- All tests are passing ✅
- Page matches app visual theme and is fully responsive ✅
- Minor future enhancement possible to reach 100% function coverage if needed

## Testing
- Run `npm run test` to verify all tests pass
- Visual testing done on both desktop and mobile breakpoints

