### PR TITLE
Use ref for scroll pagination

### DIFF
--- a/src/components/Recipe_Display/FrontDisplay.tsx
+++ b/src/components/Recipe_Display/FrontDisplay.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Image from "next/image"
 import { Button } from '@headlessui/react'
 import { HandThumbUpIcon } from '@heroicons/react/24/outline'
@@ -23,7 +24,8 @@ const getThumbsup = ({ liked, owns }: { liked: boolean, owns: boolean }) => {
 }
 
 
-function FrontDisplay({ recipe, showRecipe, updateRecipeList }: FrontDisplayProps) {
+const FrontDisplay = React.forwardRef<HTMLDivElement, FrontDisplayProps>(
+    ({ recipe, showRecipe, updateRecipeList }, ref) => {
 
     const handleRecipeLike = async (recipeId: string) => {
         try {
@@ -35,7 +37,7 @@ function FrontDisplay({ recipe, showRecipe, updateRecipeList }: FrontDisplayProp
     }
 
     return (
-        <div className="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full">
+        <div ref={ref} className="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full">
             <div className="relative w-full h-64"> {/* Add a container for the image */}
                 <Image
                     src={recipe.imgLink}
@@ -81,7 +83,8 @@ function FrontDisplay({ recipe, showRecipe, updateRecipeList }: FrontDisplayProp
         </div>
 
     )
-}
+    }
+)
 
 export default FrontDisplay
 

--- a/src/components/Recipe_Display/ViewRecipes.tsx
+++ b/src/components/Recipe_Display/ViewRecipes.tsx
@@ -5,12 +5,13 @@ import Dialog from './Dialog'
 import { ExtendedRecipe } from '../../types';
 
 interface ViewRecipesProps {
-    recipes: ExtendedRecipe[],
+    recipes: ExtendedRecipe[]
     handleRecipeListUpdate: (r: ExtendedRecipe | null, deleteId?: string) => void
+    lastRecipeRef?: React.RefObject<HTMLDivElement>
 }
 const initialDialogContents: ExtendedRecipe | null = null
 
-function ViewRecipes({ recipes, handleRecipeListUpdate }: ViewRecipesProps) {
+function ViewRecipes({ recipes, handleRecipeListUpdate, lastRecipeRef }: ViewRecipesProps) {
     const [openDialog, setOpenDialog] = useState(initialDialogContents);
 
     const handleShowRecipe = (recipe: ExtendedRecipe) => {
@@ -36,12 +37,13 @@ function ViewRecipes({ recipes, handleRecipeListUpdate }: ViewRecipesProps) {
         <>
             <div className="flex justify-center items-center min-h-screen p-5 mb-3">
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                    {recipes.map((recipe) => (
+                    {recipes.map((recipe, index) => (
                         <FrontDisplay
                             key={recipe._id}
                             recipe={recipe}
                             showRecipe={handleShowRecipe}
                             updateRecipeList={handleRecipeListUpdate}
+                            ref={index === recipes.length - 1 ? lastRecipeRef : undefined}
                         />
                     ))}
                 </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -14,6 +14,7 @@ const Home = () => {
 
     const observerRef = useRef<IntersectionObserver | null>(null);
     const searchTimeout = useRef<NodeJS.Timeout | null>(null);
+    const lastRecipeRef = useRef<HTMLDivElement | null>(null);
 
     const isSearching = searchVal.trim() !== "";
     const endpoint = isSearching ? "/api/search-recipes" : "/api/get-recipes";
@@ -37,11 +38,7 @@ const Home = () => {
     useEffect(() => {
         if (!latestRecipes.length) return;
 
-        // 🔹 TEMPORARY WORKAROUND:
-        // Instead of using a React ref, we are directly querying the DOM to attach the observer.
-        // This is because React's ref assignment is currently not triggering as expected.
-        // Once the root cause is identified, we should refactor this back to the correct React ref approach.
-        const lastRecipeElement = document.querySelector(".recipe-card:last-child");
+        const lastRecipeElement = lastRecipeRef.current;
         if (!lastRecipeElement) return;
 
         if (observerRef.current) observerRef.current.disconnect();
@@ -122,7 +119,11 @@ const Home = () => {
                 </button>
             </div>
 
-            <ViewRecipes recipes={latestRecipes} handleRecipeListUpdate={handleRecipeListUpdate} />
+            <ViewRecipes
+                recipes={latestRecipes}
+                handleRecipeListUpdate={handleRecipeListUpdate}
+                lastRecipeRef={lastRecipeRef}
+            />
             <FloatingActionButtons />
 
             {/* Show loading indicator when fetching */}


### PR DESCRIPTION
## Summary
- attach forwardRef to `FrontDisplay` so parent components can set refs
- allow `ViewRecipes` to receive `lastRecipeRef`
- hook up `lastRecipeRef` in `Home` and observe it for infinite scroll

## Testing
- `npm run all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68406586a994832b925aa8f6ff3dd958