### PR TITLE
Expand Header tests

### DIFF
--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import Header from "../../src/components/Header";
 import { render, screen, fireEvent } from '@testing-library/react'
+import { signOut } from 'next-auth/react'
 
 
 const routePushMock = jest.fn()
@@ -12,6 +13,9 @@ jest.mock("next/router", () => ({
 }))
 
 jest.mock("next/image")
+jest.mock("next-auth/react", () => ({
+    signOut: jest.fn()
+}))
 
 describe('The Header', () => {
     it('renders', () => {
@@ -44,6 +48,32 @@ describe('The Header', () => {
             <Header user={undefined} />
         )
         expect(container.firstChild).toBeNull();
+    })
+
+    it('will navigate to the /CreateRecipe route', () => {
+        render(<Header user={{ name: 'mock username' }} />)
+        fireEvent.click(screen.getByText('Create Recipes'))
+        expect(routePushMock).toHaveBeenCalledWith('/CreateRecipe')
+    })
+
+    it('opens the profile menu and navigates to the profile page', async () => {
+        render(<Header user={{ name: 'mock username' }} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Open user menu' }))
+        fireEvent.click(await screen.findByText('Your Profile'))
+        expect(routePushMock).toHaveBeenCalledWith('/Profile')
+    })
+
+    it('signs the user out when sign out is clicked', async () => {
+        render(<Header user={{ name: 'mock username' }} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Open user menu' }))
+        fireEvent.click(await screen.findByText('Sign out'))
+        expect(signOut).toHaveBeenCalled()
+    })
+
+    it('contains a buy me a coffee link', () => {
+        render(<Header user={{ name: 'mock username' }} />)
+        const link = screen.getByRole('link', { name: /buy/i })
+        expect(link).toHaveAttribute('href', 'https://www.buymeacoffee.com/dereje')
     })
 
 })


### PR DESCRIPTION
## Summary
- extend test suite for Header component

## Testing
- `npm run all_tests --silent`

------
https://chatgpt.com/codex/tasks/task_e_68419a9fcb70832b8b61dda024810ffd