### PR TITLE
Implement brand color palette

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -89,7 +89,7 @@ export default function ChatBox({ recipeId }: Props) {
                         >
                             <div
                                 className={`px-4 py-2 rounded-lg text-sm max-w-[75%] ${msg.role === 'user'
-                                    ? 'bg-blue-100 text-blue-800'
+                                    ? 'bg-brand-100 text-brand-800'
                                     : 'bg-gray-200 text-gray-800'
                                     }`}
                             >
@@ -126,7 +126,7 @@ export default function ChatBox({ recipeId }: Props) {
                 <button
                     onClick={handleSend}
                     disabled={isLoading || !input.trim() || tokenTotal >= MAX_TOKENS}
-                    className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 disabled:opacity-50"
+                    className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-brand-700 disabled:opacity-50"
                     aria-label="Send"
                 >
                     <PaperAirplaneIcon className="h-14 w-8" />

--- a/src/components/FloatingActionButtons.tsx
+++ b/src/components/FloatingActionButtons.tsx
@@ -31,7 +31,7 @@ const FloatingActionButtons = () => {
       {/* "Create Recipe" Button (Always Visible) */}
       <button
         onClick={() => router.push('/CreateRecipe')}
-        className="bg-blue-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-2xl hover:bg-blue-600 transition-all"
+        className="bg-brand-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-2xl hover:bg-brand-600 transition-all"
         aria-label="Create Recipe"
       >
         <PlusIcon className="h-6 w-6" />
@@ -41,7 +41,7 @@ const FloatingActionButtons = () => {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="bg-green-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-xl hover:bg-green-600 transition-all"
+          className="bg-brand-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-xl hover:bg-brand-600 transition-all"
           aria-label="Scroll to Top"
         >
           <ArrowUpIcon className="h-6 w-6" />

--- a/src/components/FloatingActionButtons.tsx
+++ b/src/components/FloatingActionButtons.tsx
@@ -31,7 +31,7 @@ const FloatingActionButtons = () => {
       {/* "Create Recipe" Button (Always Visible) */}
       <button
         onClick={() => router.push('/CreateRecipe')}
-        className="bg-brand-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-2xl hover:bg-brand-600 transition-all"
+        className="bg-brand-600 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-2xl hover:bg-brand-700 transition-all"
         aria-label="Create Recipe"
       >
         <PlusIcon className="h-6 w-6" />
@@ -41,7 +41,7 @@ const FloatingActionButtons = () => {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="bg-brand-500 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-xl hover:bg-brand-600 transition-all"
+          className="bg-brand-400 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-xl hover:bg-brand-500 transition-all"
           aria-label="Scroll to Top"
         >
           <ArrowUpIcon className="h-6 w-6" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,9 +11,9 @@ const userNavigation = [
 ]
 
 const navigation = [
-    { name: 'Home', route: '/Home', style: 'text-gray-300 hover:bg-green-700 hover:text-white' },
-    { name: 'Create Recipes', route: '/CreateRecipe', style: 'bg-green-500 text-white px-4 py-2 rounded-lg shadow-md hover:bg-green-600 transition-all animate-pulse' },
-    { name: 'About', route: '/', style: 'text-gray-300 hover:bg-green-700 hover:text-white' },
+    { name: 'Home', route: '/Home', style: 'text-gray-300 hover:bg-brand-700 hover:text-white' },
+    { name: 'Create Recipes', route: '/CreateRecipe', style: 'bg-brand-500 text-white px-4 py-2 rounded-lg shadow-md hover:bg-brand-600 transition-all animate-pulse' },
+    { name: 'About', route: '/', style: 'text-gray-300 hover:bg-brand-700 hover:text-white' },
 ]
 
 function classNames(...classes: string[]) {
@@ -45,7 +45,7 @@ function Header({ user }: HeaderProps) {
 
     if (!user) return null;
     return (
-        <Disclosure as="nav" className="sticky top-0 z-50 bg-green-800 shadow-md" style={{ scrollbarGutter: 'stable' }}>
+        <Disclosure as="nav" className="sticky top-0 z-50 bg-brand-800 shadow-md" style={{ scrollbarGutter: 'stable' }}>
             {({ open }) => (
                 <>
                     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -67,7 +67,7 @@ function Header({ user }: HeaderProps) {
                                                 key={item.name}
                                                 className={classNames(
                                                     item.route === router.pathname
-                                                        ? 'bg-green-50 text-gray-800'
+                                                        ? 'bg-brand-50 text-gray-800'
                                                         : item.style,
                                                     'rounded-md px-3 py-2 text-sm font-medium',
                                                 )}
@@ -95,7 +95,7 @@ function Header({ user }: HeaderProps) {
                                     {/* Profile dropdown */}
                                     <Menu as="div" className="relative ml-3">
                                         <div>
-                                            <MenuButton className="relative flex max-w-xs items-center rounded-full bg-green-800 text-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-green-800">
+                                            <MenuButton className="relative flex max-w-xs items-center rounded-full bg-brand-800 text-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-brand-800">
                                                 <span className="absolute -inset-1.5" />
                                                 <span className="sr-only">Open user menu</span>
                                                 <Image
@@ -132,7 +132,7 @@ function Header({ user }: HeaderProps) {
                             </div>
                             <div className="-mr-2 flex md:hidden">
                                 {/* Mobile menu button */}
-                                <DisclosureButton className="relative inline-flex items-center justify-center rounded-md bg-green-800 p-2 text-gray-200 hover:bg-green-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-green-800">
+                                <DisclosureButton className="relative inline-flex items-center justify-center rounded-md bg-brand-800 p-2 text-gray-200 hover:bg-brand-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-brand-800">
                                     <span className="absolute -inset-0.5" />
                                     <span className="sr-only">Open main menu</span>
                                     {open ? (
@@ -151,7 +151,7 @@ function Header({ user }: HeaderProps) {
                                 <DisclosureButton
                                     key={item.name}
                                     className={classNames(
-                                        item.route === router.pathname ? 'bg-green-50 text-gray-800' : item.style,
+                                        item.route === router.pathname ? 'bg-brand-50 text-gray-800' : item.style,
                                         'block rounded-md px-3 py-2 text-base font-medium',
                                     )}
                                     aria-current={item.route === router.pathname ? 'page' : undefined}
@@ -172,7 +172,7 @@ function Header({ user }: HeaderProps) {
                                 ☕ Buy Me a Coffee
                             </a>
                         </div>
-                        <div className="border-t border-green-700 pb-3 pt-4">
+                        <div className="border-t border-brand-700 pb-3 pt-4">
                             <div className="flex items-center px-5">
                                 <div className="flex-shrink-0">
                                     <Image
@@ -196,7 +196,7 @@ function Header({ user }: HeaderProps) {
                                 {userNavigation.map((item) => (
                                     <DisclosureButton
                                         key={item.name}
-                                        className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-green-700 hover:text-white"
+                                        className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-brand-700 hover:text-white"
                                         onClick={() => handleNavigation(item)}
                                     >
                                         {item.name}

--- a/src/components/Hero_Sections/Features.tsx
+++ b/src/components/Hero_Sections/Features.tsx
@@ -10,24 +10,24 @@ export default function Features({ resetPage }: { resetPage: () => void }) {
       </h2>
       <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400">
         <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Ingredient-based recipe generation using advanced AI algorithms.
         </li>
         <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Support for various dietary preferences like vegan, gluten-free, and more.
         </li>
         <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Easy-to-use interface for adding ingredients and generating recipes.
         </li>
         <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Save, rate, and share your favorite recipes with others.
         </li>
       </ul>
       <button
-        className="mt-10 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        className="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
         onClick={resetPage}
       >
         Back to Home

--- a/src/components/Hero_Sections/Landing.tsx
+++ b/src/components/Hero_Sections/Landing.tsx
@@ -10,7 +10,7 @@ export default function Landing() {
             </p>
             <div className="mt-10 flex items-center justify-center gap-x-6">
                 <button
-                    className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    className="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
                     onClick={() => signIn('google')}
                 >
                     Get started

--- a/src/components/Hero_Sections/Product.tsx
+++ b/src/components/Hero_Sections/Product.tsx
@@ -10,24 +10,24 @@ export default function Product({ resetPage }: { resetPage: () => void }) {
       </h2>
       <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400">
         <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           AI-powered recipe generation using your available ingredients.
         </li>
         <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Customized recipes based on dietary preferences and restrictions.
         </li>
         <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           User-friendly interface to easily add ingredients and generate recipes.
         </li>
         <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-green-500" />
+          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
           Option to save, rate, and share your favorite recipes.
         </li>
       </ul>
       <button
-        className="mt-10 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        className="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
         onClick={resetPage}
       >
         Back to Home

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -36,7 +36,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
       <div>
         <Header user={session.user} />
-        <main className="min-h-screen bg-green-50">{children}</main>
+        <main className="min-h-screen bg-brand-50">{children}</main>
       </div>
     );
   }

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -59,7 +59,7 @@ const Notifications = ({ screen }: NotificationProps) => {
     return (
         <Popover className="relative">
             <PopoverButton
-                className={`relative rounded-full bg-green-800 p-1 text-gray-200 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-green-800 ${screen === 'mobile' ? 'ml-auto' : ''
+                className={`relative rounded-full bg-brand-800 p-1 text-gray-200 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-brand-800 ${screen === 'mobile' ? 'ml-auto' : ''
                     }`}
             >
                 {/* Bell Icon */}
@@ -91,7 +91,7 @@ const Notifications = ({ screen }: NotificationProps) => {
                                     {/* Icon for read/unread */}
                                     <div className="flex-shrink-0 flex items-center justify-center h-8 w-8">
                                         {read ? (
-                                            <CheckIcon className="h-5 w-5 text-green-500" />
+                                            <CheckIcon className="h-5 w-5 text-brand-500" />
                                         ) : (
                                             <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
                                         )}
@@ -101,14 +101,14 @@ const Notifications = ({ screen }: NotificationProps) => {
                                         <div className="flex space-x-2 mt-1">
                                             {!read && (
                                                 <button
-                                                    className="text-xs text-blue-500 hover:underline"
+                                                    className="text-xs text-brand-500 hover:underline"
                                                     onClick={() => markAsRead(_id)}
                                                 >
                                                     Mark as Read
                                                 </button>
                                             )}
                                             <button
-                                                className="text-xs text-blue-500 hover:underline"
+                                                className="text-xs text-brand-500 hover:underline"
                                                 onClick={() => router.push(`/RecipeDetail?recipeId=${recipeId}`)}
                                             >
                                                 View Recipe
@@ -121,7 +121,7 @@ const Notifications = ({ screen }: NotificationProps) => {
                     )}
                     {notifications.length > 5 && (
                         <button
-                            className="mt-4 w-full text-sm text-blue-500 hover:text-blue-700"
+                            className="mt-4 w-full text-sm text-brand-500 hover:text-brand-700"
                             onClick={() => router.push('/NotificationsPage')}
                         >
                             See All Notifications

--- a/src/components/PopularTags.tsx
+++ b/src/components/PopularTags.tsx
@@ -50,8 +50,8 @@ const PopularTags = ({ tags, onTagToggle, searchVal }: PopularTagsProps) => {
                         <button
                             key={_id}
                             className={`px-3 py-1 text-sm font-medium rounded-lg transition ${activeTag === _id
-                                ? 'bg-green-700 text-white'
-                                : 'bg-green-200 text-green-800 hover:bg-green-300'
+                                ? 'bg-brand-700 text-white'
+                                : 'bg-brand-200 text-brand-800 hover:bg-brand-300'
                                 }`}
                             onClick={() => handleTagClick(_id)}
                         >

--- a/src/components/Profile_Information/ProfileInformation.tsx
+++ b/src/components/Profile_Information/ProfileInformation.tsx
@@ -23,7 +23,7 @@ function ProfileInformation({ recipes, updateSelection, selectedDisplay, AIusage
 
     // Determine progress bar color based on AI usage percentage
     const getUsageColor = (usage: number) => {
-        if (usage <= 50) return 'bg-green-500'; // Low usage: Green
+        if (usage <= 50) return 'bg-brand-500'; // Low usage: Green
         if (usage <= 75) return 'bg-yellow-500'; // Medium usage: Yellow
         return 'bg-red-500'; // High usage: Red
     };
@@ -47,7 +47,7 @@ function ProfileInformation({ recipes, updateSelection, selectedDisplay, AIusage
                         <Button
                             onClick={() => updateSelection('created')}
                             className={`bg-white rounded-md ${
-                                selectedDisplay === 'created' ? 'text-rose-700 font-bold' : 'text-black hover:text-blue-500 hover:underline'
+                                selectedDisplay === 'created' ? 'text-rose-700 font-bold' : 'text-black hover:text-brand-500 hover:underline'
                             }`}
                         >
                             Recipes Created
@@ -58,7 +58,7 @@ function ProfileInformation({ recipes, updateSelection, selectedDisplay, AIusage
                         <Button
                             onClick={() => updateSelection('votes received')}
                             className={`bg-white rounded-md ${
-                                selectedDisplay === 'votes received' ? 'text-rose-700 font-bold' : 'text-black hover:text-blue-500 hover:underline'
+                                selectedDisplay === 'votes received' ? 'text-rose-700 font-bold' : 'text-black hover:text-brand-500 hover:underline'
                             }`}
                         >
                             Votes Received
@@ -69,7 +69,7 @@ function ProfileInformation({ recipes, updateSelection, selectedDisplay, AIusage
                         <Button
                             onClick={() => updateSelection('favorites')}
                             className={`bg-white rounded-md ${
-                                selectedDisplay === 'favorites' ? 'text-rose-700 font-bold' : 'text-black hover:text-blue-500 hover:underline'
+                                selectedDisplay === 'favorites' ? 'text-rose-700 font-bold' : 'text-black hover:text-brand-500 hover:underline'
                             }`}
                         >
                             Favorites

--- a/src/components/Profile_Information/ProfileStickyBanner.tsx
+++ b/src/components/Profile_Information/ProfileStickyBanner.tsx
@@ -26,7 +26,7 @@ const ProfileStickyBanner = ({ userHasRecipes }: { userHasRecipes: boolean }) =>
           <p className="font-semibold text-lg">👩‍🍳 Ready to Cook?</p>
           <p>Create your first recipe now and share your culinary ideas!</p>
           <button
-            className="mt-2 bg-blue-500 text-white px-3 py-2 rounded-md hover:bg-blue-600 transition"
+            className="mt-2 bg-brand-500 text-white px-3 py-2 rounded-md hover:bg-brand-600 transition"
             onClick={() => router.push('/CreateRecipe')}
           >
             🍽️ Create a Recipe

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -42,7 +42,7 @@ const RecipeCard = ({ recipe, handleRecipeSelection, selectedRecipes, showSwitch
                             }
                             className={`
                 relative inline-flex flex-shrink-0
-                ${selectedRecipes.includes(recipe.openaiPromptId) ? 'bg-green-500' : 'bg-gray-300'}
+                ${selectedRecipes.includes(recipe.openaiPromptId) ? 'bg-brand-500' : 'bg-gray-300'}
                 h-[20px] w-[40px] sm:h-[28px] sm:w-[54px]
                 cursor-pointer rounded-full border-2 border-transparent
                 transition-colors duration-200 ease-in-out focus:outline-none
@@ -68,7 +68,7 @@ const RecipeCard = ({ recipe, handleRecipeSelection, selectedRecipes, showSwitch
                 <ul className="mb-4 flex flex-wrap gap-2">
                     {recipe.ingredients.map((ingredient) => (
                         <li key={ingredient.name}>
-                            <span className="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded">
+                            <span className="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded">
                                 {`${ingredient.name}${ingredient.quantity ? ` (${ingredient.quantity})` : ''}`}
                             </span>
                         </li>
@@ -92,7 +92,7 @@ const RecipeCard = ({ recipe, handleRecipeSelection, selectedRecipes, showSwitch
                 <Disclosure>
                     {({ open }) => (
                         <>
-                            <DisclosureButton className="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none">
+                            <DisclosureButton className="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none">
                                 <span>Instructions</span>
                                 <ChevronDownIcon className={`w-5 h-5 transform transition-transform duration-300 ${open ? 'rotate-180' : ''}`} />
                             </DisclosureButton>
@@ -117,7 +117,7 @@ const RecipeCard = ({ recipe, handleRecipeSelection, selectedRecipes, showSwitch
                 <Disclosure as="div" className="mt-4">
                     {({ open }) => (
                         <>
-                            <DisclosureButton className="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none">
+                            <DisclosureButton className="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none">
                                 <span>Additional Information</span>
                                 <ChevronDownIcon className={`w-5 h-5 transform transition-transform duration-300 ${open ? 'rotate-180' : ''}`} />
                             </DisclosureButton>

--- a/src/components/Recipe_Creation/DietaryPreferences.tsx
+++ b/src/components/Recipe_Creation/DietaryPreferences.tsx
@@ -57,8 +57,8 @@ export default function DietaryPreferences({
         <Checkbox
           checked={noPreference}
           onChange={handleNoPreference}
-          className={`h-5 w-5 rounded border border-gray-300 flex items-center justify-center ${noPreference ? 'bg-indigo-600' : 'bg-white'
-            } focus:outline-none focus:ring-2 focus:ring-indigo-500`}
+          className={`h-5 w-5 rounded border border-gray-300 flex items-center justify-center ${noPreference ? 'bg-brand-600' : 'bg-white'
+            } focus:outline-none focus:ring-2 focus:ring-brand-500`}
           disabled={Boolean(generatedRecipes.length)}
           aria-label="No Dietary Preference"
         >
@@ -76,8 +76,8 @@ export default function DietaryPreferences({
             <Checkbox
               checked={preferences.includes(option)}
               onChange={(e) => handlePreferenceChange(e, option)}
-              className={`h-5 w-5 rounded border border-gray-300 flex items-center justify-center ${preferences.includes(option) ? 'bg-indigo-600' : 'bg-white'
-                } focus:outline-none focus:ring-2 focus:ring-indigo-500`}
+              className={`h-5 w-5 rounded border border-gray-300 flex items-center justify-center ${preferences.includes(option) ? 'bg-brand-600' : 'bg-white'
+                } focus:outline-none focus:ring-2 focus:ring-brand-500`}
               disabled={noPreference || Boolean(generatedRecipes.length)}
               aria-label={option}
             >

--- a/src/components/Recipe_Creation/IngredientForm.tsx
+++ b/src/components/Recipe_Creation/IngredientForm.tsx
@@ -12,7 +12,7 @@ const initialComboIngredient: ComboIngredient = { id: 0, name: '' };
 
 const Chip = ({ ingredient, onDelete }: { ingredient: Ingredient; onDelete: (id: string) => void }) => {
     return (
-        <div className="flex items-center bg-indigo-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1">
+        <div className="flex items-center bg-brand-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1">
             <span>{`${ingredient.name}${ingredient.quantity ? ` (${ingredient.quantity})` : ''}`}</span>
             <button onClick={() => onDelete(ingredient.id)} className="ml-2 focus:outline-none">
                 <XMarkIcon className="w-4 h-4 text-white hover:text-gray-200" />
@@ -54,7 +54,7 @@ function IngredientList({ ingredientList, ingredientUpdate, generatedRecipes }: 
                 <div className="relative w-full">
                     <ComboboxInput
                         className={clsx(
-                            'w-full rounded-lg border border-gray-300 bg-white py-3 pr-10 pl-4 text-base text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500'
+                            'w-full rounded-lg border border-gray-300 bg-white py-3 pr-10 pl-4 text-base text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500'
                         )}
                         displayValue={(ingredient: ComboIngredient) => ingredient?.name}
                         onChange={(event) => setQuery(event.target.value)}
@@ -74,7 +74,7 @@ function IngredientList({ ingredientList, ingredientUpdate, generatedRecipes }: 
                                 key={ingredient._id}
                                 value={ingredient}
                                 className={({ active }) =>
-                                    `cursor-pointer select-none relative py-2 pl-10 pr-4 ${active ? 'text-white bg-indigo-600' : 'text-gray-900'
+                                    `cursor-pointer select-none relative py-2 pl-10 pr-4 ${active ? 'text-white bg-brand-600' : 'text-gray-900'
                                     }`
                                 }
                             >
@@ -88,7 +88,7 @@ function IngredientList({ ingredientList, ingredientUpdate, generatedRecipes }: 
                                         </span>
                                         {selected && (
                                             <span
-                                                className={`absolute inset-y-0 left-0 flex items-center pl-3 ${focus ? 'text-white' : 'text-indigo-600'
+                                                className={`absolute inset-y-0 left-0 flex items-center pl-3 ${focus ? 'text-white' : 'text-brand-600'
                                                     }`}
                                             >
                                                 <CheckIcon className="w-5 h-5" aria-hidden="true" />
@@ -172,7 +172,7 @@ export default function IngredientForm({
             </div>
             {ingredients.length > 0 && (
                 <div className="mt-6 w-full">
-                    <h2 className="text-lg font-semibold text-indigo-600 mb-3">Selected Ingredients:</h2>
+                    <h2 className="text-lg font-semibold text-brand-600 mb-3">Selected Ingredients:</h2>
                     <div className="flex flex-wrap max-h-32 overflow-y-auto">
                         {ingredients.map((ingredient: Ingredient) => (
                             <Chip

--- a/src/components/Recipe_Creation/LimitReached.tsx
+++ b/src/components/Recipe_Creation/LimitReached.tsx
@@ -38,7 +38,7 @@ const LimitReached: React.FC<LimitReachedProps> = ({
                 {/* Action Button */}
                 <Button
                     onClick={handleAction}
-                    className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                    className="bg-brand-600 text-white px-4 py-2 rounded-md hover:bg-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400"
                 >
                     {actionText}
                 </Button>

--- a/src/components/Recipe_Creation/NewIngredientDialog.tsx
+++ b/src/components/Recipe_Creation/NewIngredientDialog.tsx
@@ -92,7 +92,7 @@ function NewIngredientDialog({ ingredientList, updateIngredientList }: NewIngred
     <>
       <Button
         onClick={() => setIsOpen(true)}
-        className="inline-flex items-center px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition duration-150 ease-in-out">
+        className="inline-flex items-center px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 transition duration-150 ease-in-out">
         <PlusCircleIcon className="block mr-2 h-6 w-6" />
         Add New Ingredient
       </Button>
@@ -123,7 +123,7 @@ function NewIngredientDialog({ ingredientList, updateIngredientList }: NewIngred
               <div className="flex gap-4 flex-end">
                 <Button className="bg-gray-300 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-400" onClick={() => setIsOpen(false)}>Cancel</Button>
                 <Button
-                  className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 data-[disabled]:bg-gray-200"
+                  className="bg-brand-600 text-white px-4 py-2 rounded-md hover:bg-brand-700 data-[disabled]:bg-gray-200"
                   onClick={handleSubmit}
                   disabled={!ingredientName.trim() || isDisabled}
                 >

--- a/src/components/Recipe_Creation/ReviewIngredients.tsx
+++ b/src/components/Recipe_Creation/ReviewIngredients.tsx
@@ -49,11 +49,11 @@ const ReviewComponent = ({
             {ingredients.map((ingredient) => (
               <li
                 key={ingredient.id}
-                className="flex items-center bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full"
+                className="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
               >
                 {ingredient.name}
                 {ingredient.quantity && (
-                  <span className="ml-1 text-xs text-green-600">
+                  <span className="ml-1 text-xs text-brand-600">
                     ({ingredient.quantity})
                   </span>
                 )}
@@ -90,7 +90,7 @@ const ReviewComponent = ({
             className={`flex items-center justify-center bg-gray-200 text-gray-700 
                 px-2 py-2 sm:px-4 sm:py-2 
                 rounded-full transition duration-300 ease-in-out 
-                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500
                 ${generatedRecipes.length ? 'cursor-not-allowed opacity-50' : ''}`}
             disabled={Boolean(generatedRecipes.length)}
             aria-label="Edit your selections"
@@ -105,10 +105,10 @@ const ReviewComponent = ({
           {/* Create Recipes Button */}
           <Button
             onClick={onSubmit}
-            className={`flex items-center justify-center bg-green-600 text-white 
+            className={`flex items-center justify-center bg-brand-600 text-white
                 px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out 
-                hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                rounded-full transition duration-300 ease-in-out
+                hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500
                 ${ingredients.length < 3 || generatedRecipes.length
                 ? 'cursor-not-allowed opacity-50'
                 : ''

--- a/src/components/Recipe_Creation/ReviewRecipes.tsx
+++ b/src/components/Recipe_Creation/ReviewRecipes.tsx
@@ -38,7 +38,7 @@ const ReviewRecipesComponent = ({ generatedRecipes, selectedRecipes, handleRecip
                 {finalRecipes.length ? (
                     <Button
                         onClick={() => handleRecipeSubmit(finalRecipes)}
-                        className="flex items-center bg-blue-600 text-white px-6 py-3 rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-300 ease-in-out"
+                        className="flex items-center bg-brand-600 text-white px-6 py-3 rounded-full hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition duration-300 ease-in-out"
                         aria-label="Submit selected recipes"
                     >
                         <CheckIcon className="w-5 h-5 mr-2" aria-hidden="true" />

--- a/src/components/Recipe_Display/ActionPopover.tsx
+++ b/src/components/Recipe_Display/ActionPopover.tsx
@@ -73,7 +73,7 @@ export function ActionPopover({ handlers, states, data }: ActionPopoverProps) {
                 {
                     states.isPlayingAudio ?
                         <StopCircleIcon className="h-5 w-5 text-red-500" /> :
-                        <PlayCircleIcon className={`h-5 w-5 ${states.hasAudio ? "text-green-500" : "text-blue-500"}`} />
+                        <PlayCircleIcon className={`h-5 w-5 ${states.hasAudio ? "text-brand-500" : "text-brand-500"}`} />
                 }
 
                 {states.isPlayingAudio ? 'Stop Playing' : `${states.hasAudio ? 'Play Recipe' : 'Generate Audio'}`}
@@ -154,7 +154,7 @@ export const Alert = ({ message }: { message: string }) => {
 
     const alertContent = (
         <div
-            className={`fixed top-0 inset-x-0 mx-auto mt-5 px-4 py-3 rounded shadow-lg flex items-center bg-green-100 text-green-900 font-bold 
+            className={`fixed top-0 inset-x-0 mx-auto mt-5 px-4 py-3 rounded shadow-lg flex items-center bg-brand-100 text-brand-900 font-bold
       w-[95%] sm:w-full max-w-sm sm:max-w-md md:max-w-lg 
       ${visible ? 'opacity-100 scale-100' : 'opacity-0 scale-90'} 
       transition-all duration-300 ease-out`}
@@ -162,7 +162,7 @@ export const Alert = ({ message }: { message: string }) => {
             role="alert"
             aria-live="assertive"
         >
-            <InformationCircleIcon className="w-6 h-6 flex-shrink-0 mr-2 text-green-700" />
+            <InformationCircleIcon className="w-6 h-6 flex-shrink-0 mr-2 text-brand-700" />
             <p className="text-sm sm:text-xs md:text-[12px] leading-tight">{message}</p>
         </div>
     );

--- a/src/components/Recipe_Display/ActionPopover.tsx
+++ b/src/components/Recipe_Display/ActionPopover.tsx
@@ -73,7 +73,7 @@ export function ActionPopover({ handlers, states, data }: ActionPopoverProps) {
                 {
                     states.isPlayingAudio ?
                         <StopCircleIcon className="h-5 w-5 text-red-500" /> :
-                        <PlayCircleIcon className={`h-5 w-5 ${states.hasAudio ? "text-brand-500" : "text-brand-500"}`} />
+                        <PlayCircleIcon className={`h-5 w-5 ${states.hasAudio ? 'text-brand-600' : 'text-brand-400'}`} />
                 }
 
                 {states.isPlayingAudio ? 'Stop Playing' : `${states.hasAudio ? 'Play Recipe' : 'Generate Audio'}`}

--- a/src/components/Recipe_Display/FrontDisplay.tsx
+++ b/src/components/Recipe_Display/FrontDisplay.tsx
@@ -18,9 +18,9 @@ const getThumbsup = ({ liked, owns }: { liked: boolean, owns: boolean }) => {
         return <HandThumbUpSolid className="block h-6 w-6 text-gray-500" />
     }
     if (liked) {
-        return <HandThumbUpSolid className="block h-6 w-6 text-blue-500" />
+        return <HandThumbUpSolid className="block h-6 w-6 text-brand-500" />
     }
-    return <HandThumbUpIcon className="block h-6 w-6 text-blue-500" />
+    return <HandThumbUpIcon className="block h-6 w-6 text-brand-500" />
 }
 
 
@@ -56,21 +56,21 @@ const FrontDisplay = React.forwardRef<HTMLDivElement, FrontDisplayProps>(
             <div className="mx-auto flex">
                 {
                     recipe.dietaryPreference.map((preference) => (
-                        <span key={preference} className="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110">{preference}</span>
+                        <span key={preference} className="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110">{preference}</span>
                     ))
                 }
             </div>
             <div className="p-5">
                 <div className="flex items-center justify-between">
                     <Button
-                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-brand-700 rounded-lg hover:bg-brand-800 focus:ring-4 focus:outline-none focus:ring-brand-300"
                         onClick={() => showRecipe(recipe)}
                     >
                         See Recipe
                         <ArrowRightCircleIcon className="block ml-2 h-5 w-5" />
                     </Button>
                     <Button
-                        className="py-1.5 px-3 hover:text-blue-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
+                        className="py-1.5 px-3 hover:text-brand-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
                         onClick={() => handleRecipeLike(recipe._id)}
                         disabled={recipe.owns}
                         data-testid="like_button"

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -19,14 +19,14 @@ const SearchBar = ({ searchVal, setSearchVal, handleSearch, totalRecipes }: Sear
     };
 
     return (
-        <div className="w-full max-w-screen-lg flex items-center justify-between p-4 mt-4 rounded-full shadow-md bg-green-50 border border-green-300">
+        <div className="w-full max-w-screen-lg flex items-center justify-between p-4 mt-4 rounded-full shadow-md bg-brand-50 border border-brand-300">
             <div className="relative w-full flex items-center">
                 {/* Magnifying Glass Icon */}
-                <MagnifyingGlassIcon className="absolute left-3 h-5 w-5 text-green-700" />
+                <MagnifyingGlassIcon className="absolute left-3 h-5 w-5 text-brand-700" />
 
                 {/* Input Field */}
                 <input
-                    className="w-full pl-10 pr-10 py-2 text-sm text-gray-700 placeholder-gray-600 bg-transparent border-none rounded-full focus:outline-none focus:ring-2 focus:ring-green-200"
+                    className="w-full pl-10 pr-10 py-2 text-sm text-gray-700 placeholder-gray-600 bg-transparent border-none rounded-full focus:outline-none focus:ring-2 focus:ring-brand-200"
                     placeholder={width < 565 ? 'Search recipes...' : 'Search recipes by name, ingredient, or type...'}
                     value={searchVal}
                     onChange={(e) => setSearchVal(e.target.value)}
@@ -37,10 +37,10 @@ const SearchBar = ({ searchVal, setSearchVal, handleSearch, totalRecipes }: Sear
                 {searchVal.trim() && (
                     <div className="absolute right-3 flex items-center space-x-1">
                         <button
-                            className="text-gray-500 hover:text-green-700 focus:outline-none"
+                            className="text-gray-500 hover:text-brand-700 focus:outline-none"
                             onClick={() => setSearchVal('')}
                         >
-                            <XMarkIcon className="h-6 w-6 text-green-700" />
+                            <XMarkIcon className="h-6 w-6 text-brand-700" />
                         </button>
                         {
                             totalRecipes > 0 && <span className="text-sm text-gray-500 font-bold">{`(${totalRecipes})`}</span>
@@ -51,7 +51,7 @@ const SearchBar = ({ searchVal, setSearchVal, handleSearch, totalRecipes }: Sear
 
             {/* Search Button */}
             <button
-                className="ml-4 px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-full focus:ring-4 focus:outline-none focus:ring-green-200 transition-all duration-200"
+                className="ml-4 px-4 py-2 text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 rounded-full focus:ring-4 focus:outline-none focus:ring-brand-200 transition-all duration-200"
                 onClick={handleSearch}
             >
                 Search

--- a/src/pages/CreateRecipe.tsx
+++ b/src/pages/CreateRecipe.tsx
@@ -153,7 +153,7 @@ function Navigation({
           {/* Next Button */}
           <button
             type="button"
-            className={`flex items-center justify-center bg-indigo-600 text-white rounded-full px-4 py-2 transition duration-300 ease-in-out hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${step === steps.length - 1 || (step === 2 && !generatedRecipes.length) ? 'cursor-not-allowed opacity-50' : ''}`}
+            className={`flex items-center justify-center bg-brand-600 text-white rounded-full px-4 py-2 transition duration-300 ease-in-out hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 ${step === steps.length - 1 || (step === 2 && !generatedRecipes.length) ? 'cursor-not-allowed opacity-50' : ''}`}
             onClick={() => updateStep(+1)}
             disabled={step === steps.length - 1 || (step === 2 && !generatedRecipes.length)}
             aria-label="Go to next step"

--- a/src/pages/Hero.tsx
+++ b/src/pages/Hero.tsx
@@ -169,7 +169,7 @@ export default function Hero() {
                     <div className="hidden sm:mb-8 sm:flex sm:justify-center">
                         <div className="relative rounded-full px-3 py-1 text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
                             Discover our new AI-powered recipe generator.{' '}
-                            <a href="https://github.com/Dereje1/smart-recipe-generator" className="font-semibold text-indigo-600">
+                            <a href="https://github.com/Dereje1/smart-recipe-generator" className="font-semibold text-brand-600">
                                 <span className="absolute inset-0" aria-hidden="true" />
                                 Learn more <span aria-hidden="true">&rarr;</span>
                             </a>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -101,7 +101,7 @@ const Home = () => {
             <div className="flex space-x-4 mt-4 mb-4">
                 <button
                     onClick={() => sortRecipes('recent')}
-                    className={`disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-white flex items-center px-4 py-2 rounded shadow-md transition duration-300 ${sortOption === 'recent' ? 'bg-green-500 text-white' : 'bg-gray-200 hover:bg-gray-300 hover:shadow-lg'
+                    className={`disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-white flex items-center px-4 py-2 rounded shadow-md transition duration-300 ${sortOption === 'recent' ? 'bg-brand-500 text-white' : 'bg-gray-200 hover:bg-gray-300 hover:shadow-lg'
                         }`}
                     disabled={Boolean(searchVal.trim())}
                 >
@@ -110,7 +110,7 @@ const Home = () => {
                 </button>
                 <button
                     onClick={() => sortRecipes('popular')}
-                    className={`disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-white flex items-center px-4 py-2 rounded shadow-md transition duration-300 ${sortOption === 'popular' ? 'bg-green-500 text-white' : 'bg-gray-200 hover:bg-gray-300 hover:shadow-lg"'
+                    className={`disabled:bg-gray-200 disabled:cursor-not-allowed disabled:text-white flex items-center px-4 py-2 rounded shadow-md transition duration-300 ${sortOption === 'popular' ? 'bg-brand-500 text-white' : 'bg-gray-200 hover:bg-gray-300 hover:shadow-lg"'
                         }`}
                     disabled={Boolean(searchVal.trim())}
                 >

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -46,7 +46,7 @@ const NotificationsPage = ({ initialNotifications }: NotificationsPageProps) => 
                             {/* Icon for read/unread */}
                             <div className="flex-shrink-0 flex items-center justify-center h-10 w-10">
                                 {read ? (
-                                    <CheckIcon className="h-6 w-6 text-green-500" />
+                                    <CheckIcon className="h-6 w-6 text-brand-500" />
                                 ) : (
                                     <ExclamationCircleIcon className="h-6 w-6 text-red-500" />
                                 )}
@@ -57,14 +57,14 @@ const NotificationsPage = ({ initialNotifications }: NotificationsPageProps) => 
                                 <div className="flex space-x-2 mt-1">
                                     {!read && (
                                         <button
-                                            className="text-xs text-blue-500 hover:underline"
+                                            className="text-xs text-brand-500 hover:underline"
                                             onClick={() => markAsRead(_id)}
                                         >
                                             Mark as Read
                                         </button>
                                     )}
                                     <button
-                                        className="text-xs text-blue-500 hover:underline"
+                                        className="text-xs text-brand-500 hover:underline"
                                         onClick={() => router.push(`/RecipeDetail?recipeId=${recipeId}`)}
                                     >
                                         View Recipe

--- a/src/pages/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail.tsx
@@ -17,9 +17,9 @@ const getThumbsup = ({ liked, owns }: { liked: boolean, owns: boolean }) => {
         return <HandThumbUpSolid className={`${baseClass} text-gray-500`} />;
     }
     if (liked) {
-        return <HandThumbUpSolid className={`${baseClass} text-blue-500`} />;
+        return <HandThumbUpSolid className={`${baseClass} text-brand-500`} />;
     }
-    return <HandThumbUpIcon className={`${baseClass} text-blue-500`} />;
+    return <HandThumbUpIcon className={`${baseClass} text-brand-500`} />;
 };
 
 export default function RecipeDetail() {
@@ -116,7 +116,7 @@ export default function RecipeDetail() {
                             <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2"> {/* Responsive grid layout */}
                                 {recipeData.ingredients.map((ingredient) => (
                                     <li key={ingredient.name} className="flex items-center"> {/* Ingredient item */}
-                                        <CheckCircleIcon className="w-5 h-5 text-green-500 mr-2 flex-shrink-0" /> {/* Icon next to ingredient */}
+                                        <CheckCircleIcon className="w-5 h-5 text-brand-500 mr-2 flex-shrink-0" /> {/* Icon next to ingredient */}
                                         <span className="text-gray-700">
                                             {ingredient.name}{ingredient.quantity && ` (${ingredient.quantity})`} {/* Ingredient name and quantity */}
                                         </span>
@@ -165,7 +165,7 @@ export default function RecipeDetail() {
 
                     {/* Liked By Section */}
                     <button
-                        className="w-14 h-14 mb-3 hover:text-blue-600 hover:scale-105 hover:shadow rounded-full flex items-center justify-center"
+                        className="w-14 h-14 mb-3 hover:text-brand-600 hover:scale-105 hover:shadow rounded-full flex items-center justify-center"
                         onClick={() => handleRecipeLike(recipeData._id)}
                         disabled={recipeData.owns}
                         data-testid="like_button"

--- a/src/pages/UserActivity.tsx
+++ b/src/pages/UserActivity.tsx
@@ -114,7 +114,7 @@ export default function UserActivityPage() {
                     <div className="flex justify-center space-x-4 mt-4 mb-6">
                         <button
                             className={`px-3 py-1.5 text-sm rounded-full font-semibold ${activeTab === 'created'
-                                    ? 'bg-green-500 text-white'
+                                    ? 'bg-brand-500 text-white'
                                     : 'bg-gray-200 text-gray-800'
                                 }`}
                             onClick={() => setActiveTab('created')}
@@ -123,7 +123,7 @@ export default function UserActivityPage() {
                         </button>
                         <button
                             className={`px-3 py-1.5 text-sm rounded-full font-semibold ${activeTab === 'liked'
-                                    ? 'bg-green-500 text-white'
+                                    ? 'bg-brand-500 text-white'
                                     : 'bg-gray-200 text-gray-800'
                                 }`}
                             onClick={() => setActiveTab('liked')}

--- a/src/pages/auth/error.tsx
+++ b/src/pages/auth/error.tsx
@@ -12,7 +12,7 @@ export default function ErrorPage({ message }: { message?: string }) {
         <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
             <h1 className="text-3xl font-bold mb-4">{message || 'Sign In Error'}</h1>
             <p className="text-red-500 mb-4">{message ? '' : errorMessage}</p>
-            <Link href="/" className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+            <Link href="/" className="mt-4 px-4 py-2 bg-brand-500 text-white rounded hover:bg-brand-600">
                 Go to Home
             </Link>
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,20 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        brand: {
+          50: "#ecfdf5",
+          100: "#d1fae5",
+          200: "#a7f3d0",
+          300: "#6ee7b7",
+          400: "#34d399",
+          500: "#10b981",
+          600: "#059669",
+          700: "#047857",
+          800: "#065f46",
+          900: "#064e3b",
+        },
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":

--- a/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`The Features section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -42,7 +42,7 @@ exports[`The Features section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -61,7 +61,7 @@ exports[`The Features section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -80,7 +80,7 @@ exports[`The Features section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -96,7 +96,7 @@ exports[`The Features section renders 1`] = `
       </li>
     </ul>
     <button
-      class="mt-10 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      class="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
     >
       Back to Home
     </button>

--- a/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`The Landing section renders 1`] = `
       class="mt-10 flex items-center justify-center gap-x-6"
     >
       <button
-        class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        class="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
       >
         Get started
       </button>

--- a/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`The Product section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -42,7 +42,7 @@ exports[`The Product section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -61,7 +61,7 @@ exports[`The Product section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -80,7 +80,7 @@ exports[`The Product section renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-green-500"
+          class="block mr-2 h-6 w-6 text-brand-500"
           data-slot="icon"
           fill="currentColor"
           viewBox="0 0 24 24"
@@ -96,7 +96,7 @@ exports[`The Product section renders 1`] = `
       </li>
     </ul>
     <button
-      class="mt-10 rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      class="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
     >
       Back to Home
     </button>

--- a/tests/components/Recipe_Creation/__snapshots__/LimitReached.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/LimitReached.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`The Limit Reached Component shall render 1`] = `
         You've reached your recipe creation limit.
       </p>
       <button
-        class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        class="bg-brand-600 text-white px-4 py-2 rounded-md hover:bg-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400"
         data-headlessui-state=""
         type="button"
       >

--- a/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           aria-checked="false"
           aria-disabled="true"
           aria-label="No Dietary Preference"
-          class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
           data-disabled=""
           data-headlessui-state="disabled"
           id="headlessui-checkbox-:r7:"
@@ -46,7 +46,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegetarian"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r8:"
@@ -65,7 +65,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegan"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r9:"
@@ -84,7 +84,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Gluten-Free"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:ra:"
@@ -103,7 +103,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Dairy-Free"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rb:"
@@ -122,7 +122,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Keto"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rc:"
@@ -141,7 +141,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Halal"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rd:"
@@ -160,7 +160,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
             aria-checked="false"
             aria-disabled="true"
             aria-label="Kosher"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:re:"
@@ -191,7 +191,7 @@ exports[`The step component shall render the ingredient selection form 1`] = `
         class="flex justify-end w-full"
       >
         <button
-          class="inline-flex items-center px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition duration-150 ease-in-out"
+          class="inline-flex items-center px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 transition duration-150 ease-in-out"
           data-headlessui-state=""
           type="button"
         >
@@ -224,7 +224,7 @@ exports[`The step component shall render the ingredient selection form 1`] = `
             <input
               aria-autocomplete="list"
               aria-expanded="false"
-              class="w-full rounded-lg border border-gray-300 bg-white py-3 pr-10 pl-4 text-base text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-lg border border-gray-300 bg-white py-3 pr-10 pl-4 text-base text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               data-disabled=""
               data-headlessui-state="disabled"
               disabled=""
@@ -267,7 +267,7 @@ exports[`The step component shall render the ingredient selection form 1`] = `
         class="mt-6 w-full"
       >
         <h2
-          class="text-lg font-semibold text-indigo-600 mb-3"
+          class="text-lg font-semibold text-brand-600 mb-3"
         >
           Selected Ingredients:
         </h2>
@@ -275,7 +275,7 @@ exports[`The step component shall render the ingredient selection form 1`] = `
           class="flex flex-wrap max-h-32 overflow-y-auto"
         >
           <div
-            class="flex items-center bg-indigo-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1"
+            class="flex items-center bg-brand-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1"
           >
             <span>
               undefined
@@ -300,7 +300,7 @@ exports[`The step component shall render the ingredient selection form 1`] = `
             </button>
           </div>
           <div
-            class="flex items-center bg-indigo-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1"
+            class="flex items-center bg-brand-500 text-white text-sm font-medium px-3 py-1.5 rounded-full m-1"
           >
             <span>
               undefined
@@ -371,14 +371,14 @@ exports[`The step component shall render the review and submit recipes component
             >
               <li>
                 <span
-                  class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                  class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                 >
                   Recipe_1_Ingredient_1 (Recipe_1_Ingredient_1_quantity_1)
                 </span>
               </li>
               <li>
                 <span
-                  class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                  class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                 >
                   Recipe_1_Ingredient_2 (Recipe_1_Ingredient_2_quantity_2)
                 </span>
@@ -405,7 +405,7 @@ exports[`The step component shall render the review and submit recipes component
             </div>
             <button
               aria-expanded="false"
-              class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+              class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
               data-headlessui-state=""
               id="headlessui-disclosure-button-:rp:"
               type="button"
@@ -434,7 +434,7 @@ exports[`The step component shall render the review and submit recipes component
             >
               <button
                 aria-expanded="false"
-                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
                 data-headlessui-state=""
                 id="headlessui-disclosure-button-:rr:"
                 type="button"
@@ -466,7 +466,7 @@ exports[`The step component shall render the review and submit recipes component
       >
         <button
           aria-label="Submit selected recipes"
-          class="flex items-center bg-blue-600 text-white px-6 py-3 rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-300 ease-in-out"
+          class="flex items-center bg-brand-600 text-white px-6 py-3 rounded-full hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition duration-300 ease-in-out"
           data-headlessui-state=""
           type="button"
         >
@@ -531,10 +531,10 @@ exports[`The step component shall render the review inputs section 1`] = `
             style="max-height: 60px;"
           >
             <li
-              class="flex items-center bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full"
+              class="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
             />
             <li
-              class="flex items-center bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full"
+              class="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
             />
           </ul>
         </div>
@@ -570,7 +570,7 @@ exports[`The step component shall render the review inputs section 1`] = `
             class="flex items-center justify-center bg-gray-200 text-gray-700 
                 px-2 py-2 sm:px-4 sm:py-2 
                 rounded-full transition duration-300 ease-in-out 
-                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500
                 cursor-not-allowed opacity-50"
             data-disabled=""
             data-headlessui-state="disabled"
@@ -597,10 +597,10 @@ exports[`The step component shall render the review inputs section 1`] = `
           </button>
           <button
             aria-label="Create recipes based on your selections"
-            class="flex items-center justify-center bg-green-600 text-white 
+            class="flex items-center justify-center bg-brand-600 text-white
                 px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out 
-                hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                rounded-full transition duration-300 ease-in-out
+                hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500
                 cursor-not-allowed opacity-50"
             data-disabled=""
             data-headlessui-state="disabled"
@@ -673,7 +673,7 @@ exports[`The step component shall render the select recipes component 1`] = `
                   aria-checked="true"
                   class="
                 relative inline-flex flex-shrink-0
-                bg-green-500
+                bg-brand-500
                 h-[20px] w-[40px] sm:h-[28px] sm:w-[54px]
                 cursor-pointer rounded-full border-2 border-transparent
                 transition-colors duration-200 ease-in-out focus:outline-none
@@ -711,14 +711,14 @@ exports[`The step component shall render the select recipes component 1`] = `
               >
                 <li>
                   <span
-                    class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                    class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                   >
                     Recipe_1_Ingredient_1 (Recipe_1_Ingredient_1_quantity_1)
                   </span>
                 </li>
                 <li>
                   <span
-                    class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                    class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                   >
                     Recipe_1_Ingredient_2 (Recipe_1_Ingredient_2_quantity_2)
                   </span>
@@ -745,7 +745,7 @@ exports[`The step component shall render the select recipes component 1`] = `
               </div>
               <button
                 aria-expanded="false"
-                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
                 data-headlessui-state=""
                 id="headlessui-disclosure-button-:rg:"
                 type="button"
@@ -774,7 +774,7 @@ exports[`The step component shall render the select recipes component 1`] = `
               >
                 <button
                   aria-expanded="false"
-                  class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+                  class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
                   data-headlessui-state=""
                   id="headlessui-disclosure-button-:ri:"
                   type="button"
@@ -861,14 +861,14 @@ exports[`The step component shall render the select recipes component 1`] = `
               >
                 <li>
                   <span
-                    class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                    class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                   >
                     Recipe_2_Ingredient_1 (Recipe_2_Ingredient_1_quantity_1)
                   </span>
                 </li>
                 <li>
                   <span
-                    class="bg-green-100 text-green-800 text-sm font-medium px-2.5 py-0.5 rounded"
+                    class="bg-brand-100 text-brand-800 text-sm font-medium px-2.5 py-0.5 rounded"
                   >
                     Recipe_2_Ingredient_2 (Recipe_2_Ingredient_2_quantity_2)
                   </span>
@@ -895,7 +895,7 @@ exports[`The step component shall render the select recipes component 1`] = `
               </div>
               <button
                 aria-expanded="false"
-                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+                class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
                 data-headlessui-state=""
                 id="headlessui-disclosure-button-:rl:"
                 type="button"
@@ -924,7 +924,7 @@ exports[`The step component shall render the select recipes component 1`] = `
               >
                 <button
                   aria-expanded="false"
-                  class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none"
+                  class="flex justify-between w-full px-4 py-2 text-lg font-semibold text-left text-brand-900 bg-brand-100 rounded-lg hover:bg-brand-200 focus:outline-none"
                   data-headlessui-state=""
                   id="headlessui-disclosure-button-:rn:"
                   type="button"

--- a/tests/components/Recipe_Display/__snapshots__/FrontDisplay.test.tsx.snap
+++ b/tests/components/Recipe_Display/__snapshots__/FrontDisplay.test.tsx.snap
@@ -39,12 +39,12 @@ exports[`The single front facing display shall render 1`] = `
       class="mx-auto flex"
     >
       <span
-        class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+        class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
       >
         Recipe_1_preference_1
       </span>
       <span
-        class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+        class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
       >
         Recipe_1_preference_2
       </span>
@@ -56,7 +56,7 @@ exports[`The single front facing display shall render 1`] = `
         class="flex items-center justify-between"
       >
         <button
-          class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+          class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-brand-700 rounded-lg hover:bg-brand-800 focus:ring-4 focus:outline-none focus:ring-brand-300"
           data-headlessui-state=""
           type="button"
         >
@@ -77,14 +77,14 @@ exports[`The single front facing display shall render 1`] = `
           </svg>
         </button>
         <button
-          class="py-1.5 px-3 hover:text-blue-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
+          class="py-1.5 px-3 hover:text-brand-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
           data-headlessui-state=""
           data-testid="like_button"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="block h-6 w-6 text-blue-500"
+            class="block h-6 w-6 text-brand-500"
             data-slot="icon"
             fill="none"
             stroke="currentColor"
@@ -147,12 +147,12 @@ exports[`The single front facing display shall render for a loading recipe 1`] =
       class="mx-auto flex"
     >
       <span
-        class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+        class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
       >
         Recipe_1_preference_1
       </span>
       <span
-        class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+        class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
       >
         Recipe_1_preference_2
       </span>
@@ -164,7 +164,7 @@ exports[`The single front facing display shall render for a loading recipe 1`] =
         class="flex items-center justify-between"
       >
         <button
-          class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+          class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-brand-700 rounded-lg hover:bg-brand-800 focus:ring-4 focus:outline-none focus:ring-brand-300"
           data-headlessui-state=""
           type="button"
         >
@@ -185,14 +185,14 @@ exports[`The single front facing display shall render for a loading recipe 1`] =
           </svg>
         </button>
         <button
-          class="py-1.5 px-3 hover:text-blue-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
+          class="py-1.5 px-3 hover:text-brand-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
           data-headlessui-state=""
           data-testid="like_button"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="block h-6 w-6 text-blue-500"
+            class="block h-6 w-6 text-brand-500"
             data-slot="icon"
             fill="none"
             stroke="currentColor"

--- a/tests/components/__snapshots__/Layout.test.tsx.snap
+++ b/tests/components/__snapshots__/Layout.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`The Layout renders the hero if the user is not authenticated 1`] = `
             Discover our new AI-powered recipe generator.
              
             <a
-              class="font-semibold text-indigo-600"
+              class="font-semibold text-brand-600"
               href="https://github.com/Dereje1/smart-recipe-generator"
             >
               <span
@@ -177,7 +177,7 @@ exports[`The Layout renders the hero if the user is not authenticated 1`] = `
             class="mt-10 flex items-center justify-center gap-x-6"
           >
             <button
-              class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              class="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
             >
               Get started
             </button>

--- a/tests/pages/__snapshots__/ChatAssistant.test.tsx.snap
+++ b/tests/pages/__snapshots__/ChatAssistant.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`The ChatAssistant Page shall successfully render a recipe 1`] = `
             />
             <button
               aria-label="Send"
-              class="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 disabled:opacity-50"
+              class="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-brand-700 disabled:opacity-50"
               disabled=""
             >
               <svg

--- a/tests/pages/__snapshots__/Profile.test.tsx.snap
+++ b/tests/pages/__snapshots__/Profile.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
               1
             </div>
             <button
-              class="bg-white rounded-md text-black hover:text-blue-500 hover:underline"
+              class="bg-white rounded-md text-black hover:text-brand-500 hover:underline"
               data-headlessui-state=""
               type="button"
             >
@@ -74,7 +74,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
               1
             </div>
             <button
-              class="bg-white rounded-md text-black hover:text-blue-500 hover:underline"
+              class="bg-white rounded-md text-black hover:text-brand-500 hover:underline"
               data-headlessui-state=""
               type="button"
             >
@@ -96,7 +96,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
             class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700"
           >
             <div
-              class="bg-green-500 h-2.5 rounded-full"
+              class="bg-brand-500 h-2.5 rounded-full"
               style="width: 40%;"
             />
           </div>
@@ -146,12 +146,12 @@ exports[`The Profile component shall render for own recipes 1`] = `
             class="mx-auto flex"
           >
             <span
-              class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+              class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
             >
               Recipe_1_preference_1
             </span>
             <span
-              class="chip bg-green-100 text-green-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
+              class="chip bg-brand-100 text-brand-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded hover:scale-110"
             >
               Recipe_1_preference_2
             </span>
@@ -163,7 +163,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
               class="flex items-center justify-between"
             >
               <button
-                class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+                class="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-brand-700 rounded-lg hover:bg-brand-800 focus:ring-4 focus:outline-none focus:ring-brand-300"
                 data-headlessui-state=""
                 type="button"
               >
@@ -184,7 +184,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
                 </svg>
               </button>
               <button
-                class="py-1.5 px-3 hover:text-blue-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
+                class="py-1.5 px-3 hover:text-brand-600 hover:scale-105 hover:shadow text-center border border-gray-300 rounded-md border-gray-400 h-8 text-sm flex items-center gap-1 lg:gap-2"
                 data-disabled=""
                 data-headlessui-state="disabled"
                 data-testid="like_button"

--- a/tests/pages/__snapshots__/RecipeDetail.test.tsx.snap
+++ b/tests/pages/__snapshots__/RecipeDetail.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`The Recipe Detail Page shall succesfully render a recipe 1`] = `
                  
                 <svg
                   aria-hidden="true"
-                  class="w-5 h-5 text-green-500 mr-2 flex-shrink-0"
+                  class="w-5 h-5 text-brand-500 mr-2 flex-shrink-0"
                   data-slot="icon"
                   fill="none"
                   stroke="currentColor"
@@ -152,7 +152,7 @@ exports[`The Recipe Detail Page shall succesfully render a recipe 1`] = `
                  
                 <svg
                   aria-hidden="true"
-                  class="w-5 h-5 text-green-500 mr-2 flex-shrink-0"
+                  class="w-5 h-5 text-brand-500 mr-2 flex-shrink-0"
                   data-slot="icon"
                   fill="none"
                   stroke="currentColor"
@@ -301,7 +301,7 @@ exports[`The Recipe Detail Page shall succesfully render a recipe 1`] = `
           </div>
         </div>
         <button
-          class="w-14 h-14 mb-3 hover:text-blue-600 hover:scale-105 hover:shadow rounded-full flex items-center justify-center"
+          class="w-14 h-14 mb-3 hover:text-brand-600 hover:scale-105 hover:shadow rounded-full flex items-center justify-center"
           data-testid="like_button"
           disabled=""
         >


### PR DESCRIPTION
## Summary
- define brand green shades in Tailwind config
- replace various indigo/blue/green classes with brand classes across components and pages
- update snapshots

## Testing
- `npm run all_tests`
- `npx jest -u`


------
https://chatgpt.com/codex/tasks/task_e_68429544b17c832b9706a39f664c117a