### PR TITLE
Add fade-in animations

### DIFF
--- a/src/components/Hero_Sections/Features.tsx
+++ b/src/components/Hero_Sections/Features.tsx
@@ -3,7 +3,7 @@ import { CheckCircleIcon } from '@heroicons/react/24/solid'
 
 export default function Features({ resetPage }: { resetPage: () => void }) {
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12">
+    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp">
       <h1 className="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center">Features</h1>
       <h2 className="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl">
       Discover the features that make our product unique.

--- a/src/components/Hero_Sections/Landing.tsx
+++ b/src/components/Hero_Sections/Landing.tsx
@@ -1,7 +1,7 @@
 import { signIn } from 'next-auth/react';
 export default function Landing() {
     return (
-        <div className="text-center">
+        <div className="text-center animate-fadeInUp">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
                 Generate Delicious Recipes with Your Ingredients
             </h1>

--- a/src/components/Hero_Sections/Product.tsx
+++ b/src/components/Hero_Sections/Product.tsx
@@ -3,7 +3,7 @@ import { CheckCircleIcon } from '@heroicons/react/24/solid'
 
 export default function Product({ resetPage }: { resetPage: () => void }) {
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12">
+    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp">
       <h1 className="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center">Our Product</h1>
       <h2 className="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl">
         Learn more about the amazing features of our product.

--- a/src/components/Recipe_Display/FrontDisplay.tsx
+++ b/src/components/Recipe_Display/FrontDisplay.tsx
@@ -37,7 +37,7 @@ const FrontDisplay = React.forwardRef<HTMLDivElement, FrontDisplayProps>(
     }
 
     return (
-        <div ref={ref} className="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full">
+        <div ref={ref} className="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full animate-fadeInUp">
             <div className="relative w-full h-64"> {/* Add a container for the image */}
                 <Image
                     src={recipe.imgLink}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,15 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      keyframes: {
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        }
+      },
+      animation: {
+        fadeInUp: 'fadeInUp 0.5s ease-out forwards'
+      },
       colors: {
         brand: {
           50: "#ecfdf5",

--- a/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The Features section renders 1`] = `
 <div>
   <div
-    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12"
+    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp"
   >
     <h1
       class="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center"

--- a/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The Landing section renders 1`] = `
 <div>
   <div
-    class="text-center"
+    class="text-center animate-fadeInUp"
   >
     <h1
       class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl"

--- a/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The Product section renders 1`] = `
 <div>
   <div
-    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12"
+    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp"
   >
     <h1
       class="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center"

--- a/tests/components/Recipe_Display/__snapshots__/FrontDisplay.test.tsx.snap
+++ b/tests/components/Recipe_Display/__snapshots__/FrontDisplay.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The single front facing display shall render 1`] = `
 <div>
   <div
-    class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full"
+    class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full animate-fadeInUp"
   >
     <div
       class="relative w-full h-64"
@@ -111,7 +111,7 @@ exports[`The single front facing display shall render 1`] = `
 exports[`The single front facing display shall render for a loading recipe 1`] = `
 <div>
   <div
-    class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full"
+    class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full animate-fadeInUp"
   >
     <div
       class="relative w-full h-64"

--- a/tests/components/__snapshots__/Layout.test.tsx.snap
+++ b/tests/components/__snapshots__/Layout.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`The Layout renders the hero if the user is not authenticated 1`] = `
           </div>
         </div>
         <div
-          class="text-center"
+          class="text-center animate-fadeInUp"
         >
           <h1
             class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl"

--- a/tests/pages/__snapshots__/Profile.test.tsx.snap
+++ b/tests/pages/__snapshots__/Profile.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`The Profile component shall render for own recipes 1`] = `
         class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
       >
         <div
-          class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full"
+          class="recipe-card max-w-sm bg-gradient-to-r from-slate-200 to-stone-100 border border-gray-200 rounded-lg shadow-lg mt-4 mb-2 transform transition-transform hover:scale-105 hover:shadow-lg flex flex-col h-full animate-fadeInUp"
         >
           <div
             class="relative w-full h-64"


### PR DESCRIPTION
## Summary
- introduce `fadeInUp` animation in Tailwind config
- animate landing, product, and features hero sections
- animate individual recipe cards
- update Jest snapshots

## Testing
- `npm run all_tests`
- `npm run all_tests -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6842df340990832b98661bc80d62f368