### PR TITLE
Enhance Dietary Preferences UI

### DIFF
--- a/src/components/Recipe_Creation/DietaryPreferences.tsx
+++ b/src/components/Recipe_Creation/DietaryPreferences.tsx
@@ -73,7 +73,7 @@ export default function DietaryPreferences({
 
   return (
     <div
-      className="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-md mx-auto"
+      className="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-md md:max-w-lg mx-auto"
       style={{ width: '98%' }}
     >
       {/* Enhanced Title */}
@@ -102,7 +102,7 @@ export default function DietaryPreferences({
       <hr className="mb-4" />
 
       {/* Dietary Options with Wrapped Layout */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
         {dietaryOptions.map((option) => {
           const Icon = iconMap[option];
           const selected = preferences.includes(option);
@@ -110,7 +110,7 @@ export default function DietaryPreferences({
             <div
               key={option}
               title={tooltipMap[option]}
-              className={`flex items-center p-3 rounded-lg border transition-colors cursor-pointer ${selected ? 'bg-brand-50 border-brand-600' : 'bg-white border-gray-200 hover:bg-gray-50'} ${noPreference || generatedRecipes.length ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-md'}`}
+              className={`flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer ${selected ? 'bg-brand-50 border-brand-600' : 'bg-white border-gray-200 hover:bg-gray-50'} ${noPreference || generatedRecipes.length ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-md'}`}
               onClick={() => {
                 if (noPreference || generatedRecipes.length) return;
                 handlePreferenceChange(!selected, option);
@@ -119,13 +119,13 @@ export default function DietaryPreferences({
               <Checkbox
                 checked={selected}
                 onChange={(e) => handlePreferenceChange(e, option)}
-                className={`h-5 w-5 rounded border flex items-center justify-center ${selected ? 'bg-brand-600 border-brand-600' : 'bg-white border-gray-300'} focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors`}
+                className={`shrink-0 h-5 w-5 rounded border flex items-center justify-center ${selected ? 'bg-brand-600 border-brand-600' : 'bg-white border-gray-300'} focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors`}
                 disabled={noPreference || Boolean(generatedRecipes.length)}
                 aria-label={option}
               >
                 {selected && <CheckIcon className="h-3 w-3 text-white" />}
               </Checkbox>
-              <Icon className="w-4 h-4 text-brand-600 ml-3" aria-hidden="true" />
+              <Icon className="shrink-0 w-4 h-4 text-brand-600 ml-3" aria-hidden="true" />
               <span className="ml-2 text-gray-700">{option}</span>
             </div>
           );

--- a/src/components/Recipe_Creation/DietaryPreferences.tsx
+++ b/src/components/Recipe_Creation/DietaryPreferences.tsx
@@ -1,6 +1,15 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Checkbox } from '@headlessui/react';
-import { CheckIcon } from '@heroicons/react/24/solid';
+import {
+  CheckIcon,
+  SparklesIcon,
+  CubeIcon,
+  FireIcon,
+  CakeIcon,
+  BoltIcon,
+  GlobeAltIcon,
+  HeartIcon,
+} from '@heroicons/react/24/solid';
 import { DietaryPreference, Recipe } from '../../types/index';
 
 const dietaryOptions: DietaryPreference[] = [
@@ -12,6 +21,26 @@ const dietaryOptions: DietaryPreference[] = [
   'Halal',
   'Kosher'
 ];
+
+const iconMap: Record<DietaryPreference, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+  Vegetarian: SparklesIcon,
+  Vegan: CubeIcon,
+  'Gluten-Free': FireIcon,
+  'Dairy-Free': CakeIcon,
+  Keto: BoltIcon,
+  Halal: GlobeAltIcon,
+  Kosher: HeartIcon,
+};
+
+const tooltipMap: Record<DietaryPreference, string> = {
+  Vegetarian: 'No meat or fish',
+  Vegan: 'No animal products',
+  'Gluten-Free': 'No wheat, barley or rye',
+  'Dairy-Free': 'No milk or dairy products',
+  Keto: 'Low-carb, high-fat',
+  Halal: 'Halal-certified ingredients',
+  Kosher: 'Prepared according to Jewish dietary laws',
+};
 
 interface DietaryPreferencesProps {
   preferences: DietaryPreference[];
@@ -48,9 +77,12 @@ export default function DietaryPreferences({
       style={{ width: '98%' }}
     >
       {/* Enhanced Title */}
-      <h2 className="text-xl font-medium text-gray-800 mb-4 sm:text-2xl">
+      <h2 className="text-xl font-medium text-gray-800 mb-2 sm:text-2xl">
         Dietary Preferences
       </h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Choose as many preferences as you like—your recipes will match them!
+      </p>
 
       {/* "No Preference" Option */}
       <div className="flex items-center mb-4">
@@ -70,24 +102,34 @@ export default function DietaryPreferences({
       <hr className="mb-4" />
 
       {/* Dietary Options with Wrapped Layout */}
-      <div className="flex flex-wrap gap-3">
-        {dietaryOptions.map((option) => (
-          <div key={option} className="flex items-center">
-            <Checkbox
-              checked={preferences.includes(option)}
-              onChange={(e) => handlePreferenceChange(e, option)}
-              className={`h-5 w-5 rounded border border-gray-300 flex items-center justify-center ${preferences.includes(option) ? 'bg-brand-600' : 'bg-white'
-                } focus:outline-none focus:ring-2 focus:ring-brand-500`}
-              disabled={noPreference || Boolean(generatedRecipes.length)}
-              aria-label={option}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {dietaryOptions.map((option) => {
+          const Icon = iconMap[option];
+          const selected = preferences.includes(option);
+          return (
+            <div
+              key={option}
+              title={tooltipMap[option]}
+              className={`flex items-center p-3 rounded-lg border transition-colors cursor-pointer ${selected ? 'bg-brand-50 border-brand-600' : 'bg-white border-gray-200 hover:bg-gray-50'} ${noPreference || generatedRecipes.length ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-md'}`}
+              onClick={() => {
+                if (noPreference || generatedRecipes.length) return;
+                handlePreferenceChange(!selected, option);
+              }}
             >
-              {preferences.includes(option) && (
-                <CheckIcon className="h-3 w-3 text-white" />
-              )}
-            </Checkbox>
-            <span className="ml-3 text-gray-700">{option}</span>
-          </div>
-        ))}
+              <Checkbox
+                checked={selected}
+                onChange={(e) => handlePreferenceChange(e, option)}
+                className={`h-5 w-5 rounded border flex items-center justify-center ${selected ? 'bg-brand-600 border-brand-600' : 'bg-white border-gray-300'} focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors`}
+                disabled={noPreference || Boolean(generatedRecipes.length)}
+                aria-label={option}
+              >
+                {selected && <CheckIcon className="h-3 w-3 text-white" />}
+              </Checkbox>
+              <Icon className="w-4 h-4 text-brand-600 ml-3" aria-hidden="true" />
+              <span className="ml-2 text-gray-700">{option}</span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
@@ -10,10 +10,15 @@ exports[`The step component shall render the diet preference selection 1`] = `
       style="width: 98%;"
     >
       <h2
-        class="text-xl font-medium text-gray-800 mb-4 sm:text-2xl"
+        class="text-xl font-medium text-gray-800 mb-2 sm:text-2xl"
       >
         Dietary Preferences
       </h2>
+      <p
+        class="text-sm text-gray-500 mb-4"
+      >
+        Choose as many preferences as you like—your recipes will match them!
+      </p>
       <div
         class="flex items-center mb-4"
       >
@@ -37,137 +42,234 @@ exports[`The step component shall render the diet preference selection 1`] = `
         class="mb-4"
       />
       <div
-        class="flex flex-wrap gap-3"
+        class="grid grid-cols-2 sm:grid-cols-3 gap-3"
       >
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="No meat or fish"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegetarian"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r8:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M9 4.5a.75.75 0 0 1 .721.544l.813 2.846a3.75 3.75 0 0 0 2.576 2.576l2.846.813a.75.75 0 0 1 0 1.442l-2.846.813a3.75 3.75 0 0 0-2.576 2.576l-.813 2.846a.75.75 0 0 1-1.442 0l-.813-2.846a3.75 3.75 0 0 0-2.576-2.576l-2.846-.813a.75.75 0 0 1 0-1.442l2.846-.813A3.75 3.75 0 0 0 7.466 7.89l.813-2.846A.75.75 0 0 1 9 4.5ZM18 1.5a.75.75 0 0 1 .728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 0 1 0 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 0 1-1.456 0l-.258-1.036a2.625 2.625 0 0 0-1.91-1.91l-1.036-.258a.75.75 0 0 1 0-1.456l1.036-.258a2.625 2.625 0 0 0 1.91-1.91l.258-1.036A.75.75 0 0 1 18 1.5ZM16.5 15a.75.75 0 0 1 .712.513l.394 1.183c.15.447.5.799.948.948l1.183.395a.75.75 0 0 1 0 1.422l-1.183.395c-.447.15-.799.5-.948.948l-.395 1.183a.75.75 0 0 1-1.422 0l-.395-1.183a1.5 1.5 0 0 0-.948-.948l-1.183-.395a.75.75 0 0 1 0-1.422l1.183-.395c.447-.15.799-.5.948-.948l.395-1.183A.75.75 0 0 1 16.5 15Z"
+              fill-rule="evenodd"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Vegetarian
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="No animal products"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegan"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r9:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.378 1.602a.75.75 0 0 0-.756 0L3 6.632l9 5.25 9-5.25-8.622-5.03ZM21.75 7.93l-9 5.25v9l8.628-5.032a.75.75 0 0 0 .372-.648V7.93ZM11.25 22.18v-9l-9-5.25v8.57a.75.75 0 0 0 .372.648l8.628 5.033Z"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Vegan
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="No wheat, barley or rye"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Gluten-Free"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:ra:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M12.963 2.286a.75.75 0 0 0-1.071-.136 9.742 9.742 0 0 0-3.539 6.176 7.547 7.547 0 0 1-1.705-1.715.75.75 0 0 0-1.152-.082A9 9 0 1 0 15.68 4.534a7.46 7.46 0 0 1-2.717-2.248ZM15.75 14.25a3.75 3.75 0 1 1-7.313-1.172c.628.465 1.35.81 2.133 1a5.99 5.99 0 0 1 1.925-3.546 3.75 3.75 0 0 1 3.255 3.718Z"
+              fill-rule="evenodd"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Gluten-Free
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="No milk or dairy products"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Dairy-Free"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rb:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m15 1.784-.796.795a1.125 1.125 0 1 0 1.591 0L15 1.784ZM12 1.784l-.796.795a1.125 1.125 0 1 0 1.591 0L12 1.784ZM9 1.784l-.796.795a1.125 1.125 0 1 0 1.591 0L9 1.784ZM9.75 7.547c.498-.021.998-.035 1.5-.042V6.75a.75.75 0 0 1 1.5 0v.755c.502.007 1.002.021 1.5.042V6.75a.75.75 0 0 1 1.5 0v.88l.307.022c1.55.117 2.693 1.427 2.693 2.946v1.018a62.182 62.182 0 0 0-13.5 0v-1.018c0-1.519 1.143-2.829 2.693-2.946l.307-.022v-.88a.75.75 0 0 1 1.5 0v.797ZM12 12.75c-2.472 0-4.9.184-7.274.54-1.454.217-2.476 1.482-2.476 2.916v.384a4.104 4.104 0 0 1 2.585.364 2.605 2.605 0 0 0 2.33 0 4.104 4.104 0 0 1 3.67 0 2.605 2.605 0 0 0 2.33 0 4.104 4.104 0 0 1 3.67 0 2.605 2.605 0 0 0 2.33 0 4.104 4.104 0 0 1 2.585-.364v-.384c0-1.434-1.022-2.7-2.476-2.917A49.138 49.138 0 0 0 12 12.75ZM21.75 18.131a2.604 2.604 0 0 0-1.915.165 4.104 4.104 0 0 1-3.67 0 2.605 2.605 0 0 0-2.33 0 4.104 4.104 0 0 1-3.67 0 2.605 2.605 0 0 0-2.33 0 4.104 4.104 0 0 1-3.67 0 2.604 2.604 0 0 0-1.915-.165v2.494c0 1.035.84 1.875 1.875 1.875h15.75c1.035 0 1.875-.84 1.875-1.875v-2.494Z"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Dairy-Free
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="Low-carb, high-fat"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Keto"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rc:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M14.615 1.595a.75.75 0 0 1 .359.852L12.982 9.75h7.268a.75.75 0 0 1 .548 1.262l-10.5 11.25a.75.75 0 0 1-1.272-.71l1.992-7.302H3.75a.75.75 0 0 1-.548-1.262l10.5-11.25a.75.75 0 0 1 .913-.143Z"
+              fill-rule="evenodd"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Keto
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="Halal-certified ingredients"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Halal"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rd:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21.721 12.752a9.711 9.711 0 0 0-.945-5.003 12.754 12.754 0 0 1-4.339 2.708 18.991 18.991 0 0 1-.214 4.772 17.165 17.165 0 0 0 5.498-2.477ZM14.634 15.55a17.324 17.324 0 0 0 .332-4.647c-.952.227-1.945.347-2.966.347-1.021 0-2.014-.12-2.966-.347a17.515 17.515 0 0 0 .332 4.647 17.385 17.385 0 0 0 5.268 0ZM9.772 17.119a18.963 18.963 0 0 0 4.456 0A17.182 17.182 0 0 1 12 21.724a17.18 17.18 0 0 1-2.228-4.605ZM7.777 15.23a18.87 18.87 0 0 1-.214-4.774 12.753 12.753 0 0 1-4.34-2.708 9.711 9.711 0 0 0-.944 5.004 17.165 17.165 0 0 0 5.498 2.477ZM21.356 14.752a9.765 9.765 0 0 1-7.478 6.817 18.64 18.64 0 0 0 1.988-4.718 18.627 18.627 0 0 0 5.49-2.098ZM2.644 14.752c1.682.971 3.53 1.688 5.49 2.099a18.64 18.64 0 0 0 1.988 4.718 9.765 9.765 0 0 1-7.478-6.816ZM13.878 2.43a9.755 9.755 0 0 1 6.116 3.986 11.267 11.267 0 0 1-3.746 2.504 18.63 18.63 0 0 0-2.37-6.49ZM12 2.276a17.152 17.152 0 0 1 2.805 7.121c-.897.23-1.837.353-2.805.353-.968 0-1.908-.122-2.805-.353A17.151 17.151 0 0 1 12 2.276ZM10.122 2.43a18.629 18.629 0 0 0-2.37 6.49 11.266 11.266 0 0 1-3.746-2.504 9.754 9.754 0 0 1 6.116-3.985Z"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Halal
           </span>
         </div>
         <div
-          class="flex items-center"
+          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          title="Prepared according to Jewish dietary laws"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Kosher"
-            class="h-5 w-5 rounded border border-gray-300 flex items-center justify-center bg-white focus:outline-none focus:ring-2 focus:ring-brand-500"
+            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:re:"
             role="checkbox"
           />
+          <svg
+            aria-hidden="true"
+            class="w-4 h-4 text-brand-600 ml-3"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m11.645 20.91-.007-.003-.022-.012a15.247 15.247 0 0 1-.383-.218 25.18 25.18 0 0 1-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0 1 12 5.052 5.5 5.5 0 0 1 16.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 0 1-4.244 3.17 15.247 15.247 0 0 1-.383.219l-.022.012-.007.004-.003.001a.752.752 0 0 1-.704 0l-.003-.001Z"
+            />
+          </svg>
           <span
-            class="ml-3 text-gray-700"
+            class="ml-2 text-gray-700"
           >
             Kosher
           </span>

--- a/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
     class="mt-8"
   >
     <div
-      class="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-md mx-auto"
+      class="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-md md:max-w-lg mx-auto"
       style="width: 98%;"
     >
       <h2
@@ -42,17 +42,17 @@ exports[`The step component shall render the diet preference selection 1`] = `
         class="mb-4"
       />
       <div
-        class="grid grid-cols-2 sm:grid-cols-3 gap-3"
+        class="grid grid-cols-2 md:grid-cols-3 gap-3"
       >
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="No meat or fish"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegetarian"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r8:"
@@ -60,7 +60,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -79,14 +79,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="No animal products"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Vegan"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:r9:"
@@ -94,7 +94,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -111,14 +111,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="No wheat, barley or rye"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Gluten-Free"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:ra:"
@@ -126,7 +126,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -145,14 +145,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="No milk or dairy products"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Dairy-Free"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rb:"
@@ -160,7 +160,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -177,14 +177,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="Low-carb, high-fat"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Keto"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rc:"
@@ -192,7 +192,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -211,14 +211,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="Halal-certified ingredients"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Halal"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:rd:"
@@ -226,7 +226,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"
@@ -243,14 +243,14 @@ exports[`The step component shall render the diet preference selection 1`] = `
           </span>
         </div>
         <div
-          class="flex items-center p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+          class="flex items-center p-2 sm:p-3 rounded-lg border transition-colors cursor-pointer bg-white border-gray-200 hover:bg-gray-50 opacity-50 cursor-not-allowed"
           title="Prepared according to Jewish dietary laws"
         >
           <span
             aria-checked="false"
             aria-disabled="true"
             aria-label="Kosher"
-            class="h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+            class="shrink-0 h-5 w-5 rounded border flex items-center justify-center bg-white border-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
             data-disabled=""
             data-headlessui-state="disabled"
             id="headlessui-checkbox-:re:"
@@ -258,7 +258,7 @@ exports[`The step component shall render the diet preference selection 1`] = `
           />
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-brand-600 ml-3"
+            class="shrink-0 w-4 h-4 text-brand-600 ml-3"
             data-slot="icon"
             fill="currentColor"
             viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- add icon and tooltip mapping for dietary options
- style preferences as grid of cards with icons and transitions
- update snapshot for StepComponent

## Testing
- `npm run compileTS`
- `npm run all_tests -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6842e884e97c832bb30f0ae187972bee