### PR TITLE
Enhance ReviewIngredients design

### DIFF
--- a/src/components/Recipe_Creation/ReviewIngredients.tsx
+++ b/src/components/Recipe_Creation/ReviewIngredients.tsx
@@ -1,8 +1,32 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@headlessui/react';
-import { PencilIcon, ChevronRightIcon } from '@heroicons/react/24/solid';
+import {
+  PencilIcon,
+  ChevronRightIcon,
+  CheckCircleIcon,
+  SparklesIcon,
+  CubeIcon,
+  FireIcon,
+  CakeIcon,
+  BoltIcon,
+  GlobeAltIcon,
+  HeartIcon,
+} from '@heroicons/react/24/solid';
 import { Ingredient, DietaryPreference, Recipe } from '../../types/index';
 import useWindowSize from '../Hooks/useWindowSize';
+
+const preferenceIconMap: Record<
+  DietaryPreference,
+  React.ComponentType<React.SVGProps<SVGSVGElement>>
+> = {
+  Vegetarian: SparklesIcon,
+  Vegan: CubeIcon,
+  'Gluten-Free': FireIcon,
+  'Dairy-Free': CakeIcon,
+  Keto: BoltIcon,
+  Halal: GlobeAltIcon,
+  Kosher: HeartIcon,
+};
 
 interface ReviewComponentProps {
   ingredients: Ingredient[];
@@ -23,7 +47,7 @@ const ReviewComponent = ({
 
   return (
     <div
-      className="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-xl mx-auto"
+      className="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl mx-auto animate-fadeInUp"
       style={{ width: '98%' }}
     >
       <div className="px-1 py-1">
@@ -32,6 +56,9 @@ const ReviewComponent = ({
           <h2 className="text-2xl font-medium text-gray-800 sm:text-3xl">
             Review Your Selections
           </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Make sure everything looks right before we start cooking!
+          </p>
           {ingredients.length < 3 && (
             <p className="text-sm text-red-500 mt-2">
               Please select at least 3 ingredients to proceed with recipe creation.
@@ -51,6 +78,7 @@ const ReviewComponent = ({
                 key={ingredient.id}
                 className="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
               >
+                <CheckCircleIcon className="w-4 h-4 mr-1 text-brand-600" aria-hidden="true" />
                 {ingredient.name}
                 {ingredient.quantity && (
                   <span className="ml-1 text-xs text-brand-600">
@@ -71,14 +99,18 @@ const ReviewComponent = ({
             className="flex flex-wrap gap-2 overflow-y-auto"
             style={{ maxHeight: '70px' }}
           >
-            {dietaryPreference.map((preference) => (
-              <span
-                key={preference}
-                className="bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
-              >
-                {preference}
-              </span>
-            ))}
+            {dietaryPreference.map((preference) => {
+              const Icon = preferenceIconMap[preference] || SparklesIcon;
+              return (
+                <span
+                  key={preference}
+                  className="flex items-center bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
+                >
+                  <Icon className="w-4 h-4 mr-1 text-brand-600" aria-hidden="true" />
+                  {preference}
+                </span>
+              );
+            })}
           </div>
         </div>
 
@@ -87,10 +119,10 @@ const ReviewComponent = ({
           {/* Edit Button */}
           <Button
             onClick={onEdit}
-            className={`flex items-center justify-center bg-gray-200 text-gray-700 
-                px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out 
-                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500
+            className={`flex items-center justify-center bg-gray-200 text-gray-700
+                px-2 py-2 sm:px-4 sm:py-2
+                rounded-full transition duration-300 ease-in-out transform
+                hover:bg-gray-300 hover:shadow-md hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-500
                 ${generatedRecipes.length ? 'cursor-not-allowed opacity-50' : ''}`}
             disabled={Boolean(generatedRecipes.length)}
             aria-label="Edit your selections"
@@ -106,9 +138,9 @@ const ReviewComponent = ({
           <Button
             onClick={onSubmit}
             className={`flex items-center justify-center bg-brand-600 text-white
-                px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out
-                hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500
+                px-2 py-2 sm:px-4 sm:py-2
+                rounded-full transition duration-300 ease-in-out transform
+                hover:bg-brand-700 hover:shadow-md hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-500
                 ${ingredients.length < 3 || generatedRecipes.length
                 ? 'cursor-not-allowed opacity-50'
                 : ''

--- a/src/components/Recipe_Creation/ReviewIngredients.tsx
+++ b/src/components/Recipe_Creation/ReviewIngredients.tsx
@@ -47,8 +47,7 @@ const ReviewComponent = ({
 
   return (
     <div
-      className="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl mx-auto animate-fadeInUp"
-      style={{ width: '98%' }}
+      className="fixed top-36 mt-48 inset-x-0 mx-auto w-11/12 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl animate-fadeInUp"
     >
       <div className="px-1 py-1">
         {/* Enhanced Title */}

--- a/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
@@ -600,8 +600,7 @@ exports[`The step component shall render the review inputs section 1`] = `
     class="mt-8"
   >
     <div
-      class="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl mx-auto animate-fadeInUp"
-      style="width: 98%;"
+      class="fixed top-36 mt-48 inset-x-0 mx-auto w-11/12 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl animate-fadeInUp"
     >
       <div
         class="px-1 py-1"

--- a/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
+++ b/tests/components/Recipe_Creation/__snapshots__/StepComponent.test.tsx.snap
@@ -600,7 +600,7 @@ exports[`The step component shall render the review inputs section 1`] = `
     class="mt-8"
   >
     <div
-      class="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-white shadow-md rounded-xl sm:max-w-xl mx-auto"
+      class="fixed top-36 mt-48 pl-2 left-1/2 transform -translate-x-1/2 px-4 py-6 bg-gradient-to-br from-slate-50 to-stone-100 shadow-md rounded-xl sm:max-w-xl mx-auto animate-fadeInUp"
       style="width: 98%;"
     >
       <div
@@ -614,6 +614,11 @@ exports[`The step component shall render the review inputs section 1`] = `
           >
             Review Your Selections
           </h2>
+          <p
+            class="text-sm text-gray-500 mt-1"
+          >
+            Make sure everything looks right before we start cooking!
+          </p>
           <p
             class="text-sm text-red-500 mt-2"
           >
@@ -634,10 +639,40 @@ exports[`The step component shall render the review inputs section 1`] = `
           >
             <li
               class="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
-            />
+            >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4 mr-1 text-brand-600"
+                data-slot="icon"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
             <li
               class="flex items-center bg-brand-100 text-brand-800 text-sm font-medium px-3 py-1 rounded-full"
-            />
+            >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4 mr-1 text-brand-600"
+                data-slot="icon"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
           </ul>
         </div>
         <div
@@ -653,13 +688,41 @@ exports[`The step component shall render the review inputs section 1`] = `
             style="max-height: 70px;"
           >
             <span
-              class="bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
+              class="flex items-center bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
             >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4 mr-1 text-brand-600"
+                data-slot="icon"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M9 4.5a.75.75 0 0 1 .721.544l.813 2.846a3.75 3.75 0 0 0 2.576 2.576l2.846.813a.75.75 0 0 1 0 1.442l-2.846.813a3.75 3.75 0 0 0-2.576 2.576l-.813 2.846a.75.75 0 0 1-1.442 0l-.813-2.846a3.75 3.75 0 0 0-2.576-2.576l-2.846-.813a.75.75 0 0 1 0-1.442l2.846-.813A3.75 3.75 0 0 0 7.466 7.89l.813-2.846A.75.75 0 0 1 9 4.5ZM18 1.5a.75.75 0 0 1 .728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 0 1 0 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 0 1-1.456 0l-.258-1.036a2.625 2.625 0 0 0-1.91-1.91l-1.036-.258a.75.75 0 0 1 0-1.456l1.036-.258a2.625 2.625 0 0 0 1.91-1.91l.258-1.036A.75.75 0 0 1 18 1.5ZM16.5 15a.75.75 0 0 1 .712.513l.394 1.183c.15.447.5.799.948.948l1.183.395a.75.75 0 0 1 0 1.422l-1.183.395c-.447.15-.799.5-.948.948l-.395 1.183a.75.75 0 0 1-1.422 0l-.395-1.183a1.5 1.5 0 0 0-.948-.948l-1.183-.395a.75.75 0 0 1 0-1.422l1.183-.395c.447-.15.799-.5.948-.948l.395-1.183A.75.75 0 0 1 16.5 15Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
               preference-1
             </span>
             <span
-              class="bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
+              class="flex items-center bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full"
             >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4 mr-1 text-brand-600"
+                data-slot="icon"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M9 4.5a.75.75 0 0 1 .721.544l.813 2.846a3.75 3.75 0 0 0 2.576 2.576l2.846.813a.75.75 0 0 1 0 1.442l-2.846.813a3.75 3.75 0 0 0-2.576 2.576l-.813 2.846a.75.75 0 0 1-1.442 0l-.813-2.846a3.75 3.75 0 0 0-2.576-2.576l-2.846-.813a.75.75 0 0 1 0-1.442l2.846-.813A3.75 3.75 0 0 0 7.466 7.89l.813-2.846A.75.75 0 0 1 9 4.5ZM18 1.5a.75.75 0 0 1 .728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 0 1 0 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 0 1-1.456 0l-.258-1.036a2.625 2.625 0 0 0-1.91-1.91l-1.036-.258a.75.75 0 0 1 0-1.456l1.036-.258a2.625 2.625 0 0 0 1.91-1.91l.258-1.036A.75.75 0 0 1 18 1.5ZM16.5 15a.75.75 0 0 1 .712.513l.394 1.183c.15.447.5.799.948.948l1.183.395a.75.75 0 0 1 0 1.422l-1.183.395c-.447.15-.799.5-.948.948l-.395 1.183a.75.75 0 0 1-1.422 0l-.395-1.183a1.5 1.5 0 0 0-.948-.948l-1.183-.395a.75.75 0 0 1 0-1.422l1.183-.395c.447-.15.799-.5.948-.948l.395-1.183A.75.75 0 0 1 16.5 15Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
               preference-2
             </span>
           </div>
@@ -669,10 +732,10 @@ exports[`The step component shall render the review inputs section 1`] = `
         >
           <button
             aria-label="Edit your selections"
-            class="flex items-center justify-center bg-gray-200 text-gray-700 
-                px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out 
-                hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-brand-500
+            class="flex items-center justify-center bg-gray-200 text-gray-700
+                px-2 py-2 sm:px-4 sm:py-2
+                rounded-full transition duration-300 ease-in-out transform
+                hover:bg-gray-300 hover:shadow-md hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-500
                 cursor-not-allowed opacity-50"
             data-disabled=""
             data-headlessui-state="disabled"
@@ -700,9 +763,9 @@ exports[`The step component shall render the review inputs section 1`] = `
           <button
             aria-label="Create recipes based on your selections"
             class="flex items-center justify-center bg-brand-600 text-white
-                px-2 py-2 sm:px-4 sm:py-2 
-                rounded-full transition duration-300 ease-in-out
-                hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500
+                px-2 py-2 sm:px-4 sm:py-2
+                rounded-full transition duration-300 ease-in-out transform
+                hover:bg-brand-700 hover:shadow-md hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-500
                 cursor-not-allowed opacity-50"
             data-disabled=""
             data-headlessui-state="disabled"


### PR DESCRIPTION
## Summary
- style ReviewIngredients panel with gradient background and fade-in animation
- add tagline and icons to ingredients and dietary chips
- improve button hover/scale transitions
- update snapshot for StepComponent

## Testing
- `npm run compileTS`
- `npm run all_tests -- -u`

------
https://chatgpt.com/codex/tasks/task_e_684302a93740832ba9d150d0a184260b