### PR TITLE
Implement split-screen layout for recipe creation

### DIFF
--- a/src/components/Recipe_Creation/RecipePreview.tsx
+++ b/src/components/Recipe_Creation/RecipePreview.tsx
@@ -1,0 +1,33 @@
+import RecipeCard from '../RecipeCard';
+import { Recipe } from '../../types/index';
+
+interface RecipePreviewProps {
+  generatedRecipes: Recipe[];
+  selectedRecipes: string[];
+}
+
+export default function RecipePreview({ generatedRecipes, selectedRecipes }: RecipePreviewProps) {
+  const previewRecipes = selectedRecipes.length
+    ? generatedRecipes.filter(r => selectedRecipes.includes(r.openaiPromptId))
+    : generatedRecipes;
+
+  return (
+    <div className="bg-white shadow-lg rounded-xl p-4 sticky top-20 overflow-y-auto max-h-screen">
+      <h2 className="text-xl font-semibold mb-4">Recipe Preview</h2>
+      {previewRecipes.length === 0 ? (
+        <p className="text-gray-500">Generated recipes will appear here.</p>
+      ) : (
+        <div className="space-y-6">
+          {previewRecipes.map(recipe => (
+            <RecipeCard
+              key={recipe.openaiPromptId}
+              recipe={recipe}
+              selectedRecipes={selectedRecipes}
+              removeMargin
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/CreateRecipe.tsx
+++ b/src/pages/CreateRecipe.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { v4 as uuidv4 } from 'uuid';
-import { ChevronRightIcon, ChevronLeftIcon } from '@heroicons/react/24/solid';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import Loading from '../components/Loading';
 import StepComponent from '../components/Recipe_Creation/StepComponent';
 import LimitReached from '../components/Recipe_Creation/LimitReached';
+import RecipePreview from '../components/Recipe_Creation/RecipePreview';
 import { call_api, getServerSidePropsUtility } from '../utils/utils';
 import { Ingredient, DietaryPreference, Recipe, IngredientDocumentType } from '../types/index';
 
@@ -50,11 +51,6 @@ function Navigation({
     }
   }, [oldIngredients]);
 
-  const updateStep = (val: number) => {
-    let newStep = step + val;
-    if (newStep < 0 || newStep >= steps.length) newStep = 0;
-    setStep(newStep);
-  };
 
   const handleIngredientSubmit = async () => {
     try {
@@ -115,7 +111,6 @@ function Navigation({
     }
   };
 
-  const isWideLayout = step >= 3;
 
   return recipeCreationData.reachedLimit ? (
     <LimitReached
@@ -124,71 +119,49 @@ function Navigation({
       fullHeight
     />
   ) : (
-<div className="relative flex flex-col items-center justify-center min-h-screen bg-gradient-to-r from-gray-100 to-white p-8">
-  {/* Fixed Navigation */}
-  <div className="fixed inset-x-0 top-14 sm:top-20 flex flex-col items-center justify-center p-1 sm:p-2 z-20">
-    <div
-      className={`w-full bg-white shadow-lg rounded-2xl p-4 sm:p-8 transition-all duration-300 ease-in-out ${isWideLayout ? 'max-w-7xl' : 'max-w-3xl'}`}
-    >
-      <div className="flex flex-col items-center">
-        <div className="text-center">
-          <h2>
-            Step {step + 1}: {steps[step]}
-          </h2>
-        </div>
+    <div className="flex flex-col md:flex-row min-h-screen bg-gradient-to-r from-gray-100 to-white p-4 md:p-8 space-y-4 md:space-y-0 md:space-x-6">
+      <div className="md:w-1/2 space-y-4">
+        {steps.map((title, idx) => (
+          <div key={title} className="bg-white shadow rounded-xl">
+            <button
+              className="w-full flex items-center justify-between p-4 font-medium text-left"
+              onClick={() => setStep(idx)}
+            >
+              <span>{`Step ${idx + 1}: ${title}`}</span>
+              <ChevronDownIcon
+                className={`w-5 h-5 transform transition-transform ${step === idx ? 'rotate-180' : ''}`}
+              />
+            </button>
+            {step === idx && (
+              <div className="p-4">
+                {isLoading ? (
+                  <Loading isProgressBar isComplete={isComplete} loadingType={loadingType} />
+                ) : (
+                  <StepComponent
+                    step={idx}
+                    ingredientList={recipeCreationData.ingredientList}
+                    ingredients={ingredients}
+                    updateIngredients={setIngredients}
+                    preferences={preferences}
+                    updatePreferences={setPreferences}
+                    editInputs={() => setStep(0)}
+                    handleIngredientSubmit={handleIngredientSubmit}
+                    generatedRecipes={generatedRecipes}
+                    updateSelectedRecipes={setSelectedRecipeIds}
+                    selectedRecipes={selectedRecipeIds}
+                    handleRecipeSubmit={handleRecipeSubmit}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
 
-        <div className="flex justify-between w-full mt-6">
-          {/* Prev Button */}
-          <button
-            type="button"
-            className={`flex items-center justify-center bg-gray-200 text-gray-700 rounded-full px-4 py-2 transition duration-300 ease-in-out hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500 ${step === 0 ? 'cursor-not-allowed opacity-50' : ''}`}
-            onClick={() => updateStep(-1)}
-            disabled={step === 0}
-            aria-label="Go to previous step"
-          >
-            <ChevronLeftIcon className="block mr-2 h-5 w-5"/>
-            Prev
-          </button>
-
-          {/* Next Button */}
-          <button
-            type="button"
-            className={`flex items-center justify-center bg-brand-600 text-white rounded-full px-4 py-2 transition duration-300 ease-in-out hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 ${step === steps.length - 1 || (step === 2 && !generatedRecipes.length) ? 'cursor-not-allowed opacity-50' : ''}`}
-            onClick={() => updateStep(+1)}
-            disabled={step === steps.length - 1 || (step === 2 && !generatedRecipes.length)}
-            aria-label="Go to next step"
-          >
-            Next
-            <ChevronRightIcon className="block ml-2 h-5 w-5" />
-          </button>
-        </div>
+      <div className="md:w-1/2">
+        <RecipePreview generatedRecipes={generatedRecipes} selectedRecipes={selectedRecipeIds} />
       </div>
     </div>
-  </div>
-
-  {/* Main Content with Top Padding to Avoid Overlap */}
-  <div className="w-full pt-32 sm:pt-40 overflow-auto max-w-7xl">
-    {isLoading ? (
-      <Loading isProgressBar isComplete={isComplete} loadingType={loadingType}/>
-    ) : (
-      <StepComponent
-        step={step}
-        ingredientList={recipeCreationData.ingredientList}
-        ingredients={ingredients}
-        updateIngredients={setIngredients}
-        preferences={preferences}
-        updatePreferences={setPreferences}
-        editInputs={() => setStep(0)}
-        handleIngredientSubmit={handleIngredientSubmit}
-        generatedRecipes={generatedRecipes}
-        updateSelectedRecipes={setSelectedRecipeIds}
-        selectedRecipes={selectedRecipeIds}
-        handleRecipeSubmit={handleRecipeSubmit}
-      />
-    )}
-  </div>
-</div>
-
   );
 }
 

--- a/tests/pages/CreateRecipe.test.tsx
+++ b/tests/pages/CreateRecipe.test.tsx
@@ -1,5 +1,5 @@
 import CreateRecipe, { getServerSideProps } from "../../src/pages/CreateRecipe";
-import { fireEvent, render, screen, } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as apiCalls from "../../src/utils/utils";
 import { stubRecipeBatch, ingredientListStub } from "../stub";
 
@@ -23,19 +23,19 @@ describe('The creating recipes component', () => {
     it('will increase the current step', async () => {
         render(<CreateRecipe recipeCreationData={{ ingredientList: [], reachedLimit: false }} />)
         expect(await screen.findByText('Step 1: Choose Ingredients')).toBeInTheDocument()
-        const nextButton = await screen.findByText('Next')
-        fireEvent.click(nextButton)
-        expect(await screen.findByText('Step 2: Choose Diet')).toBeInTheDocument()
+        const step2Header = await screen.findByText('Step 2: Choose Diet')
+        fireEvent.click(step2Header)
+        expect(await screen.findByText('Dietary Preferences')).toBeInTheDocument()
     })
     it('will decrease the current step', async () => {
         render(<CreateRecipe recipeCreationData={{ ingredientList: [], reachedLimit: false }} />)
         expect(await screen.findByText('Step 1: Choose Ingredients')).toBeInTheDocument()
-        const nextButton = await screen.findByText('Next')
-        fireEvent.click(nextButton)
-        expect(await screen.findByText('Step 2: Choose Diet')).toBeInTheDocument()
-        const prevButton = await screen.findByText('Prev')
-        fireEvent.click(prevButton)
-        expect(await screen.findByText('Step 1: Choose Ingredients')).toBeInTheDocument()
+        const step2Header = await screen.findByText('Step 2: Choose Diet')
+        fireEvent.click(step2Header)
+        expect(await screen.findByText('Dietary Preferences')).toBeInTheDocument()
+        const step1Header = await screen.findByText('Step 1: Choose Ingredients')
+        fireEvent.click(step1Header)
+        expect(await screen.findByText('Add New Ingredient')).toBeInTheDocument()
     })
     it('will not allow recipe creation if limit has been reached', async () => {
         render(<CreateRecipe recipeCreationData={{ ingredientList: [], reachedLimit: true }} />)
@@ -54,25 +54,22 @@ describe('Start to finish recipe creation and submission', () => {
 
         render(<CreateRecipe recipeCreationData={{ ingredientList: ingredientListStub, reachedLimit: false }}/>)
         expect(await screen.findByText('Step 1: Choose Ingredients')).toBeInTheDocument()
-        // Find and click the combo button to choose at least 3 ingredients
-        const allButtons = await screen.findAllByRole('button');
-        const comboButton = allButtons[3]
-        
+        // Select at least 3 ingredients from the combobox
+        const comboButton = document.querySelector('[id^="headlessui-combobox-button"]') as HTMLElement
+        const comboInput = screen.getByRole('combobox')
         fireEvent.mouseDown(comboButton);
-        const ingredient1 = await screen.findByRole("option", { name: "Test-Ingredient-1" });
-        fireEvent.mouseDown(ingredient1)
-        // click combo button again to display the options
+        const ingredient1 = await screen.findByRole('option', { name: 'Test-Ingredient-1' });
+        fireEvent.mouseDown(ingredient1);
         fireEvent.mouseDown(comboButton);
-        const ingredient2 = await screen.findByRole("option", { name: "Test-Ingredient-2" });
-        fireEvent.mouseDown(ingredient2)
-        // click combo button again to display the options
+        const ingredient2 = await screen.findByRole('option', { name: 'Test-Ingredient-2' });
+        fireEvent.mouseDown(ingredient2);
         fireEvent.mouseDown(comboButton);
-        const ingredient3 = await screen.findByRole("option", { name: "Test-Ingredient-3" });
-        fireEvent.mouseDown(ingredient3)
-        // add dietary preferences
-        const nextButton = await screen.findByText('Next')
-        fireEvent.click(nextButton)
-        expect(await screen.findByText('Step 2: Choose Diet')).toBeInTheDocument()
+        const ingredient3 = await screen.findByRole('option', { name: 'Test-Ingredient-3' });
+        fireEvent.mouseDown(ingredient3);
+        // move to dietary preferences
+        const step2Header = await screen.findByText('Step 2: Choose Diet')
+        fireEvent.click(step2Header)
+        expect(await screen.findByText('Dietary Preferences')).toBeInTheDocument()
         const preferences = screen.getAllByRole('checkbox')
         // first uncheck no prefrences and assert
         fireEvent.click(preferences[0]);
@@ -80,8 +77,9 @@ describe('Start to finish recipe creation and submission', () => {
         fireEvent.click(preferences[2]);
         fireEvent.click(preferences[4]);
         await screen.findByText('Dietary Preferences')
-        // go to next screen to assert selections and submit
-        fireEvent.click(nextButton)
+        // go to review screen to assert selections and submit
+        const step3Header = await screen.findByText('Step 3: Review and Create Recipes')
+        fireEvent.click(step3Header)
         expect(await screen.findByText('Test-Ingredient-1')).toBeInTheDocument()
         expect(await screen.findByText('Test-Ingredient-2')).toBeInTheDocument()
         expect(await screen.findByText('Test-Ingredient-3')).toBeInTheDocument()
@@ -90,20 +88,21 @@ describe('Start to finish recipe creation and submission', () => {
         // mock api and submit
         const createRecipesButton = await screen.findByText('Create Recipes')
         fireEvent.click(createRecipesButton);
-        // select all recipes and move to submission
-        const selectRecipesPage = await screen.findByText('Step 4: Select Recipes')
-        expect(selectRecipesPage).toBeInTheDocument()
+        const step4Header = await screen.findByText('Step 4: Select Recipes')
+        fireEvent.click(step4Header)
+        await screen.findByText('Use the switch on each recipe to select or unselect.')
         const switches = screen.getAllByRole('switch')
         fireEvent.click(switches[0]);
         fireEvent.click(switches[1]);
-        fireEvent.click(nextButton)
-        const rescipeSubmissionPage = await screen.findByText('Step 5: Review and Save Recipes')
+        const step5Header = await screen.findByText('Step 5: Review and Save Recipes')
+        fireEvent.click(step5Header)
+        const rescipeSubmissionPage = await screen.findByText('Submit Selected (2) Recipes')
         expect(rescipeSubmissionPage).toBeInTheDocument()
         const submitRecipesButton = await screen.findByText('Submit Selected (2) Recipes')
         fireEvent.click(submitRecipesButton)
         // goes back to ingredient page as router push to home is mocked
         await screen.findByText('Step 1: Choose Ingredients')
-        expect(routePushMock).toHaveBeenCalledWith('/Profile')
+        await waitFor(() => expect(routePushMock).toHaveBeenCalledWith('/Profile'))
         expect(getRecipesFromAPI).toHaveBeenNthCalledWith(1, {
             "address": "/api/generate-recipes",
             "method": "post",


### PR DESCRIPTION
## Summary
- add `RecipePreview` for persistent preview pane
- refactor `CreateRecipe` page into collapsible split-screen layout
- update tests for new UI interactions

## Testing
- `npm run compileTS`
- `npm run all_tests`

------
https://chatgpt.com/codex/tasks/task_e_6844270e0498832b8d6be2ae1b147e85