### PR TITLE
Add Cypress E2E Tests for All Recipe Card Actions

### DIFF
--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -152,4 +152,25 @@ describe('Recipe Card Actions', () => {
       cy.contains('button', 'Stop Playing').should('be.visible');
     });
   });
+
+  describe('Delete Recipe', () => {
+    it('deletes a recipe', () => {
+      cy.visit('/Home');
+
+      const first = recipes[0];
+
+      cy.intercept('DELETE', '/api/delete-recipe', {
+        statusCode: 200,
+        body: { message: `Deleted recipe with id ${first._id}` },
+      }).as('deleteRecipe');
+
+      cy.contains('See Recipe').first().click();
+      cy.get('button[id^="headlessui-popover-button"]').eq(1).click({ force: true });
+      cy.contains('button', 'Delete Recipe').click();
+      cy.contains('button', 'Delete').click();
+
+      cy.wait('@deleteRecipe');
+      cy.contains(first.name).should('not.exist');
+    });
+  });
 });

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -56,7 +56,9 @@ describe('Recipe Card Actions', () => {
       cy.get('button[id^="headlessui-popover-button"]').eq(1).click({ force: true });
       cy.contains('button', 'Copy Link').click();
 
-      cy.contains(`${first.name} copied to clipboard!`).should('be.visible');
+      cy.get('@clipboard').should('have.been.calledWith', `http://localhost:3000/RecipeDetail?recipeId=${first._id}`);
+
+      cy.get('p.leading-tight').invoke('text').should('include', `${first.name} copied to clipboard!`);
     });
   });
 });

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -80,6 +80,7 @@ describe('Recipe Card Actions', () => {
       cy.location('pathname').should('eq', '/ChatAssistant');
       cy.location('search').should('eq', `?recipeId=${first._id}`);
       cy.contains('Ask the AI Assistant').should('be.visible');
+      cy.contains(first.name).should('be.visible');
     });
   });
 });

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -38,4 +38,25 @@ describe('Recipe Card Actions', () => {
       cy.contains(first.name).should('be.visible');
     });
   });
+
+  describe('Copy Link', () => {
+    it('copies recipe link to clipboard', () => {
+      cy.visit('/Home');
+
+      cy.window().then((win) => {
+        if (!win.navigator.clipboard) {
+          (win as any).navigator.clipboard = { writeText: () => Promise.resolve() };
+        }
+        cy.stub(win.navigator.clipboard, 'writeText').as('clipboard');
+      });
+
+      const first = recipes[0];
+
+      cy.contains('See Recipe').first().click();
+      cy.get('button[id^="headlessui-popover-button"]').eq(1).click({ force: true });
+      cy.contains('button', 'Copy Link').click();
+
+      cy.contains(`${first.name} copied to clipboard!`).should('be.visible');
+    });
+  });
 });

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -119,7 +119,7 @@ describe('Recipe Card Actions', () => {
     });
   });
 
-  describe('Play Recipe', () => {
+  describe.only('Play Recipe', () => {
     it('plays recipe audio', () => {
       cy.visit('/Home');
 
@@ -128,9 +128,11 @@ describe('Recipe Card Actions', () => {
         cy.stub(win, 'Audio').callsFake(() => {
           const audio: any = {
             load: () => {
-              if (typeof audio.oncanplaythrough === 'function') {
-                audio.oncanplaythrough();
-              }
+              setTimeout(() => {
+                if (typeof audio.oncanplaythrough === 'function') {
+                  audio.oncanplaythrough();
+                }
+              }, 50); // give React time to attach the handler
             },
             play: playStub,
             preload: 'auto',
@@ -140,13 +142,6 @@ describe('Recipe Card Actions', () => {
           };
           return audio;
         });
-      });
-
-      const first = recipes[0];
-
-      cy.intercept('GET', '/api/get-single-recipe*', {
-        statusCode: 200,
-        body: first,
       });
 
       cy.contains('See Recipe').first().click();

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -61,4 +61,25 @@ describe('Recipe Card Actions', () => {
       cy.get('p.leading-tight').invoke('text').should('include', `${first.name} copied to clipboard!`);
     });
   });
+
+  describe('Chat with Assistant', () => {
+    it('navigates to the assistant chat page', () => {
+      cy.visit('/Home');
+
+      const first = recipes[0];
+
+      cy.intercept('GET', '/api/get-single-recipe*', {
+        statusCode: 200,
+        body: first,
+      });
+
+      cy.contains('See Recipe').first().click();
+      cy.get('button[id^="headlessui-popover-button"]').eq(1).click({ force: true });
+      cy.contains('button', 'Chat with Assistant').click();
+
+      cy.location('pathname').should('eq', '/ChatAssistant');
+      cy.location('search').should('eq', `?recipeId=${first._id}`);
+      cy.contains('Ask the AI Assistant').should('be.visible');
+    });
+  });
 });

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -92,11 +92,6 @@ describe('Recipe Card Actions', () => {
 
       const first = recipes[0];
 
-      cy.intercept('GET', '/api/get-single-recipe*', {
-        statusCode: 200,
-        body: first,
-      });
-
       cy.intercept('GET', /_next\/data\/.*\/CreateRecipe\.json/, {
         statusCode: 200,
         body: {

--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -119,7 +119,7 @@ describe('Recipe Card Actions', () => {
     });
   });
 
-  describe.only('Play Recipe', () => {
+  describe('Play Recipe', () => {
     it('plays recipe audio', () => {
       cy.visit('/Home');
 


### PR DESCRIPTION
### Summary
This PR adds full end-to-end coverage for all interactive actions available from the **Recipe Card modal**. The `Open Recipe` test was already covered in a previous commit — this PR completes the remaining actions using Cypress.

### 🔍 What’s Covered

* **Copy Link**

  * Stubs the clipboard API and confirms the link is copied with the correct message shown.
* **Chat with Assistant**

  * Navigates to the assistant chat page and verifies the query string and UI rendering.
* **Clone Ingredients**

  * Navigates to the recipe creation page with the correct ingredient prefill from the original recipe.
* **Play Recipe**

  * Stubs the browser `Audio` API and verifies the audio playback is triggered and UI reflects state change.
* **Delete Recipe**

  * Confirms that clicking "Delete" removes the recipe and verifies the backend call and UI update.

### 🔧 Implementation Notes

* Recipes are loaded once via a shared `beforeEach` and stored in a `recipes` variable.
* Stubbed clipboard and audio APIs ensure stable testing of browser-dependent functionality.
* The `ingredientListStub` is used for consistency with other test cases like cloning ingredients.
* Each test is scoped within its own `describe()` block under the parent `Recipe Card Actions` group for clarity.

### 📸 Example UI Action Items Tested

Includes:

* Open Recipe ✅ *(already implemented)*
* Copy Link ✅
* Chat with Assistant ✅
* Clone Ingredients ✅
* Play Recipe ✅
* Delete Recipe ✅
