### PR TITLE
Add infinite scroll e2e test

### DIFF
--- a/cypress/e2e/infiniteScroll.cy.ts
+++ b/cypress/e2e/infiniteScroll.cy.ts
@@ -1,0 +1,49 @@
+
+// Infinite scroll test for Home page
+
+describe('Home page infinite scrolling', () => {
+  beforeEach(() => {
+    cy.mockSession();
+    cy.mockGetNotifications();
+
+    cy.fixture('recipes').then((page1) => {
+      cy.intercept('GET', '/api/get-recipes?page=1&limit=12&sortOption=popular', {
+        statusCode: 200,
+        body: {
+          recipes: page1,
+          currentPage: 1,
+          totalPages: 2,
+          popularTags: [],
+          totalRecipes: 4,
+        },
+      }).as('getRecipesPage1');
+    });
+
+    cy.fixture('recipesPage2').then((page2) => {
+      cy.intercept('GET', '/api/get-recipes?page=2&limit=12&sortOption=popular', {
+        statusCode: 200,
+        body: {
+          recipes: page2,
+          currentPage: 2,
+          totalPages: 2,
+          popularTags: [],
+          totalRecipes: 4,
+        },
+      }).as('getRecipesPage2');
+    });
+
+    cy.login();
+  });
+
+  it('loads more recipes when scrolling to the bottom', () => {
+    cy.visit('/Home');
+
+    cy.wait('@getRecipesPage1');
+    cy.get('.recipe-card').should('have.length', 2);
+
+    cy.get('.recipe-card').last().scrollIntoView();
+    cy.wait('@getRecipesPage2');
+
+    cy.get('.recipe-card').should('have.length', 4);
+  });
+});

--- a/cypress/fixtures/recipesPage2.json
+++ b/cypress/fixtures/recipesPage2.json
@@ -1,0 +1,104 @@
+[
+  {
+    "_id": "6683b8d38475eac9af5fe838",
+    "owner": {
+      "_id": "6687d83725254486590fec59",
+      "name": "user_1",
+      "image": "https://user1.img.link"
+    },
+    "name": "Recipe_1_name",
+    "ingredients": [
+      {
+        "name": "Recipe_1_Ingredient_1",
+        "quantity": "Recipe_1_Ingredient_1_quantity_1",
+        "_id": "6683b8d38475eac9af5fe839"
+      },
+      {
+        "name": "Recipe_1_Ingredient_2",
+        "quantity": "Recipe_1_Ingredient_2_quantity_2",
+        "_id": "6683b8d38475eac9af5fe83a"
+      }
+    ],
+    "instructions": [
+      "Recipe_1_Instructions_1.",
+      "Recipe_1_Instructions_2."
+    ],
+    "dietaryPreference": [
+      "Recipe_1_preference_1",
+      "Recipe_1_preference_2"
+    ],
+    "additionalInformation": {
+      "tips": "Recipe_1_tips",
+      "variations": "Recipe_1_variations",
+      "servingSuggestions": "Recipe_1_servingSuggestions",
+      "nutritionalInformation": "Recipe_1_nutritionalInformation"
+    },
+    "imgLink": "https://smart-recipe-generator.s3.amazonaws.com/Recipe_1",
+    "openaiPromptId": "6683b8908475eac9af5fe834",
+    "likedBy": [
+      {
+        "_id": "668550b989b50bfdbcc56198",
+        "name": "user_2",
+        "image": "https://user2.img.link"
+      }
+    ],
+    "comments": [],
+    "tags": [{ "tag": "specialtag", "_id": "stub_tag_id" }],
+    "createdAt": "2024-07-02T08:22:43.168Z",
+    "updatedAt": "2024-07-06T15:13:00.968Z",
+    "__v": 0,
+    "owns": true,
+    "liked": false
+  },
+  {
+    "_id": "6683b8d38475eac9af5fe83d",
+    "owner": {
+      "_id": "668550b989b50bfdbcc56198",
+      "name": "user_2",
+      "image": "https://user2.img.link"
+    },
+    "name": "Recipe_2_name",
+    "ingredients": [
+      {
+        "name": "Recipe_2_Ingredient_1",
+        "quantity": "Recipe_2_Ingredient_1_quantity_1",
+        "_id": "6683b8d38475eac9af5fe840"
+      },
+      {
+        "name": "Recipe_2_Ingredient_2",
+        "quantity": "Recipe_2_Ingredient_2_quantity_2",
+        "_id": "6683b8d38475eac9af5fe83c"
+      }
+    ],
+    "instructions": [
+      "Recipe_2_Instructions_1.",
+      "Recipe_2_Instructions_2."
+    ],
+    "dietaryPreference": [
+      "Recipe_2_preference_1",
+      "Recipe_2_preference_2"
+    ],
+    "additionalInformation": {
+      "tips": "Recipe_2_tips",
+      "variations": "Recipe_2_variations",
+      "servingSuggestions": "Recipe_2_servingSuggestions",
+      "nutritionalInformation": "Recipe_2_nutritionalInformation"
+    },
+    "imgLink": "https://smart-recipe-generator.s3.amazonaws.com/Recipe_2",
+    "openaiPromptId": "6683b8908475eac9af5fe836",
+    "likedBy": [
+      {
+        "_id": "6687d83725254486590fec59",
+        "name": "user_1",
+        "image": "https://user1.img.link"
+      }
+    ],
+    "comments": [],
+    "tags": [],
+    "createdAt": "2024-07-02T08:22:43.168Z",
+    "updatedAt": "2024-07-06T15:13:00.968Z",
+    "__v": 0,
+    "owns": false,
+    "liked": true
+  }
+]

--- a/docs/e2e-assessment.md
+++ b/docs/e2e-assessment.md
@@ -22,6 +22,7 @@ The `smart-recipe-generator` project includes a robust suite of Cypress-based E2
   * Clone Ingredients
   * Play Audio
   * Delete Recipe
+* ✅ **Home page infinite scroll** loads additional recipes when scrolling to the bottom (`infiniteScroll.cy.ts`)
 
 Each of these flows is mock-driven and uses `cy.intercept()` and custom commands like `mockSession`, `mockGetRecipes`, and `mockGetNotifications` to simulate backend behavior.
 
@@ -35,7 +36,7 @@ The current tests verify core recipe interactions but **miss several other impor
 | ----------------------------- | ------------ | -------------------------------------------------------------------------- |
 | **Search / Filtering**        | ❌ Not tested | Includes tag selection, search query input, and response filtering         |
 | **Sorting Recipes**           | ❌ Not tested | Covers sorting by newest, popular, etc.                                    |
-| **Infinite Scrolling**        | ❌ Not tested | Ensure that pagination and lazy loading are functional                     |
+| **Infinite Scrolling**        | ✅ Covered    | Verified loading additional recipes when scrolling (`infiniteScroll.cy.ts`) |
 | **Liking / Unliking Recipes** | ❌ Not tested | Implemented in backend and UI (`/RecipeDetail`, `/Home`)                   |
 | **Notifications Page**        | ❌ Not tested | No E2E for reading notifications, marking as read, or navigating from them |
 | **Chat Assistant Messages**   | ❌ Not tested | Only navigation is tested—no E2E covering actual chat interaction          |
@@ -65,7 +66,6 @@ The current tests verify core recipe interactions but **miss several other impor
 
    * Search + tag filters
    * Sorting UI
-   * Infinite scroll scroll-triggered loads
    * Liking / unliking from card and detail page
    * Notifications: unread indicator, routing, and marking as read
    * Full AI chat interaction


### PR DESCRIPTION
## Summary
- add Cypress test covering infinite scrolling on the Home page
- provide second recipe fixture for page two

## Testing
- `npm run compileTS`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68497fbe996c832ba02b4c0dae8601cd