### PR TITLE
Add E2E coverage for search filtering

### DIFF
--- a/cypress/e2e/searchFiltering.cy.ts
+++ b/cypress/e2e/searchFiltering.cy.ts
@@ -1,0 +1,56 @@
+describe('Search and filter recipes', () => {
+
+  beforeEach(() => {
+    cy.mockSession();
+    cy.mockGetRecipes();
+    cy.mockGetNotifications();
+
+    cy.fixture('recipes').then((data) => {
+      cy.intercept(
+        'GET',
+        '/api/search-recipes?query=vegan&page=1&limit=12',
+        {
+          statusCode: 200,
+          body: {
+            recipes: [data[0]],
+            currentPage: 1,
+            totalPages: 1,
+            popularTags: [],
+            totalRecipes: 1,
+          },
+        }
+      ).as('searchRecipes');
+    });
+
+    cy.login();
+  });
+
+  it('searches via the input field and clears the search', () => {
+    cy.visit('/Home');
+
+    cy.get('.recipe-card').should('have.length', 2);
+
+    cy.get('input[placeholder^="Search recipes"]').type('vegan');
+    cy.contains('button', 'Search').click();
+    cy.wait('@searchRecipes');
+
+    cy.get('.recipe-card').should('have.length', 1);
+
+    cy.get('input[placeholder^="Search recipes"]').parent().find('button').click({ force: true });
+
+    cy.get('.recipe-card').should('have.length', 2);
+  });
+
+  it('filters recipes using a popular tag', () => {
+    cy.visit('/Home');
+
+    cy.contains('button', 'vegan (3)').click();
+    cy.wait('@searchRecipes');
+
+    cy.get('.recipe-card').should('have.length', 1);
+
+    cy.contains('button', 'vegan (3)').click();
+
+    cy.get('.recipe-card').should('have.length', 2);
+  });
+});

--- a/docs/e2e-assessment.md
+++ b/docs/e2e-assessment.md
@@ -23,6 +23,7 @@ The `smart-recipe-generator` project includes a robust suite of Cypress-based E2
   * Play Audio
   * Delete Recipe
 * ✅ **Home page infinite scroll** loads additional recipes when scrolling to the bottom (`infiniteScroll.cy.ts`)
+* ✅ **Search and filtering** via search bar and tags (`searchFiltering.cy.ts`)
 
 Each of these flows is mock-driven and uses `cy.intercept()` and custom commands like `mockSession`, `mockGetRecipes`, and `mockGetNotifications` to simulate backend behavior.
 
@@ -34,7 +35,7 @@ The current tests verify core recipe interactions but **miss several other impor
 
 | Feature                       | E2E Status   | Notes                                                                      |
 | ----------------------------- | ------------ | -------------------------------------------------------------------------- |
-| **Search / Filtering**        | ❌ Not tested | Includes tag selection, search query input, and response filtering         |
+| **Search / Filtering**        | ✅ Covered    | Verified search and tag filtering (`searchFiltering.cy.ts`)                |
 | **Sorting Recipes**           | ❌ Not tested | Covers sorting by newest, popular, etc.                                    |
 | **Infinite Scrolling**        | ✅ Covered    | Verified loading additional recipes when scrolling (`infiniteScroll.cy.ts`) |
 | **Liking / Unliking Recipes** | ❌ Not tested | Implemented in backend and UI (`/RecipeDetail`, `/Home`)                   |


### PR DESCRIPTION
## Summary
- add Cypress test for search and tag filtering

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6849cee0d374832b9a1133230c75566d