### PR TITLE
Add e2e test for recipe sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ npm run compileTS
 ```
 
 ### End-to-End Tests
-Ensure the dev server is running (`npm run dev`), then run Cypress:
+Run all Cypress tests with the provided script which automatically starts the
+development server:
 ```bash
-npx cypress run
+npm run test:e2e
 ```
 For the interactive UI:
 ```bash

--- a/cypress/e2e/sortRecipes.cy.ts
+++ b/cypress/e2e/sortRecipes.cy.ts
@@ -1,0 +1,51 @@
+// E2E tests for sorting recipes by newest and popular
+
+describe('Recipe sorting', () => {
+  beforeEach(() => {
+    cy.mockSession();
+    cy.mockGetNotifications();
+
+    cy.fixture('recipes').then((popular) => {
+      cy.intercept('GET', '/api/get-recipes?page=1&limit=12&sortOption=popular', {
+        statusCode: 200,
+        body: {
+          recipes: popular,
+          currentPage: 1,
+          totalPages: 1,
+          popularTags: [],
+          totalRecipes: popular.length,
+        },
+      }).as('getPopular');
+    });
+
+    cy.fixture('recipesPage2').then((recent) => {
+      cy.intercept('GET', '/api/get-recipes?page=1&limit=12&sortOption=recent', {
+        statusCode: 200,
+        body: {
+          recipes: recent,
+          currentPage: 1,
+          totalPages: 1,
+          popularTags: [],
+          totalRecipes: recent.length,
+        },
+      }).as('getRecent');
+    });
+
+    cy.login();
+  });
+
+  it('sorts by newest and switches back to popular', () => {
+    cy.visit('/Home');
+
+    cy.wait('@getPopular');
+    cy.contains('Blueberry Apple Smoothie').should('be.visible');
+
+    cy.contains('button', 'Most Recent').click();
+    cy.wait('@getRecent');
+    cy.contains('Recipe_1_name').should('be.visible');
+
+    cy.contains('button', 'Most Popular').click();
+    cy.wait('@getPopular');
+    cy.contains('Blueberry Apple Smoothie').should('be.visible');
+  });
+});

--- a/docs/e2e-assessment.md
+++ b/docs/e2e-assessment.md
@@ -24,6 +24,7 @@ The `smart-recipe-generator` project includes a robust suite of Cypress-based E2
   * Delete Recipe
 * ✅ **Home page infinite scroll** loads additional recipes when scrolling to the bottom (`infiniteScroll.cy.ts`)
 * ✅ **Search and filtering** via search bar and tags (`searchFiltering.cy.ts`)
+* ✅ **Sorting recipes** by newest or most popular (`sortRecipes.cy.ts`)
 
 Each of these flows is mock-driven and uses `cy.intercept()` and custom commands like `mockSession`, `mockGetRecipes`, and `mockGetNotifications` to simulate backend behavior.
 
@@ -36,7 +37,7 @@ The current tests verify core recipe interactions but **miss several other impor
 | Feature                       | E2E Status   | Notes                                                                      |
 | ----------------------------- | ------------ | -------------------------------------------------------------------------- |
 | **Search / Filtering**        | ✅ Covered    | Verified search and tag filtering (`searchFiltering.cy.ts`)                |
-| **Sorting Recipes**           | ❌ Not tested | Covers sorting by newest, popular, etc.                                    |
+| **Sorting Recipes**           | ✅ Covered    | Verified sorting by newest and popular (`sortRecipes.cy.ts`)               |
 | **Infinite Scrolling**        | ✅ Covered    | Verified loading additional recipes when scrolling (`infiniteScroll.cy.ts`) |
 | **Liking / Unliking Recipes** | ❌ Not tested | Implemented in backend and UI (`/RecipeDetail`, `/Home`)                   |
 | **Notifications Page**        | ❌ Not tested | No E2E for reading notifications, marking as read, or navigating from them |
@@ -66,7 +67,6 @@ The current tests verify core recipe interactions but **miss several other impor
 1. **Cover Feature Gaps**:
 
    * Search + tag filters
-   * Sorting UI
    * Liking / unliking from card and detail page
    * Notifications: unread indicator, routing, and marking as read
    * Full AI chat interaction


### PR DESCRIPTION
## Summary
- add Cypress test for sorting recipes by date or popularity
- clarify README instructions for running Cypress tests
- mark sorting as covered in end-to-end assessment

## Testing
- `npm run compileTS`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684a7d6ee358832b9254d72fbbdd5aed