### PR TITLE
[pages] improve landing page

### DIFF
--- a/cypress/e2e/landing.cy.ts
+++ b/cypress/e2e/landing.cy.ts
@@ -1,6 +1,6 @@
 describe('Guest Landing page', () => {
   it('loads the landing page', () => {
     cy.visit('/')
-    cy.contains('Generate Delicious Recipes with Your Ingredients')
+    cy.contains('Cook Smarter with AI')
   })
 })

--- a/src/components/Hero_Sections/Features.tsx
+++ b/src/components/Hero_Sections/Features.tsx
@@ -1,37 +1,58 @@
 import React from 'react';
-import { CheckCircleIcon } from '@heroicons/react/24/solid'
+import { signIn } from 'next-auth/react';
+import Image from 'next/image';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 
 export default function Features({ resetPage }: { resetPage: () => void }) {
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp">
-      <h1 className="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center">Features</h1>
-      <h2 className="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl">
-      Discover the features that make our product unique.
-      </h2>
-      <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400">
-        <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Ingredient-based recipe generation using advanced AI algorithms.
-        </li>
-        <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Support for various dietary preferences like vegan, gluten-free, and more.
-        </li>
-        <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Easy-to-use interface for adding ingredients and generating recipes.
-        </li>
-        <li className="flex items-center text-lg">
-        <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Save, rate, and share your favorite recipes with others.
-        </li>
-      </ul>
-      <button
-        className="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
-        onClick={resetPage}
-      >
-        Back to Home
-      </button>
+    <div className="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20">
+      <div className="flex flex-col items-center text-center md:items-start md:w-1/2 md:text-left space-y-6">
+        <h1 className="text-4xl font-semibold text-gray-900 dark:text-white">Features</h1>
+        <p className="text-lg leading-8 text-gray-600">
+          Explore what makes Smart Recipe Generator unique.
+        </p>
+        <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400 text-left">
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Ingredient-based recipe generation using advanced AI algorithms.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Support for various dietary preferences like vegan, gluten-free, and more.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Easy-to-use interface for adding ingredients and generating recipes.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Save, rate, and share your favorite recipes with others.
+          </li>
+        </ul>
+        <div className="flex gap-4">
+          <button
+            className="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+            onClick={() => signIn('google')}
+          >
+            Get started
+          </button>
+          <button
+            className="w-fit rounded-md bg-gray-200 px-5 py-3 text-base font-semibold text-gray-900 transition hover:bg-gray-300"
+            onClick={resetPage}
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+      <div className="md:w-1/2">
+        <Image
+          src="/demo.gif"
+          alt="Smart Recipe Generator demo"
+          width={600}
+          height={400}
+          className="rounded-xl shadow-xl"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/Hero_Sections/Landing.tsx
+++ b/src/components/Hero_Sections/Landing.tsx
@@ -1,20 +1,31 @@
 import { signIn } from 'next-auth/react';
+import Image from 'next/image';
+
 export default function Landing() {
     return (
-        <div className="text-center animate-fadeInUp">
-            <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
-                Generate Delicious Recipes with Your Ingredients
-            </h1>
-            <p className="mt-6 text-lg leading-8 text-gray-600">
-                Simply input your available ingredients, select dietary preferences, and let our AI create unique and delicious recipes just for you.
-            </p>
-            <div className="mt-10 flex items-center justify-center gap-x-6">
+        <div className="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20">
+            <div className="flex flex-col items-center text-center md:items-start md:text-left md:w-1/2 space-y-6">
+                <h1 className="text-5xl font-extrabold tracking-tight text-gray-900">
+                    Cook Smarter with AI
+                </h1>
+                <p className="text-lg leading-8 text-gray-600">
+                    Drop in the ingredients you have on hand and let our AI whip up creative recipes tailored to your dietary needs.
+                </p>
                 <button
-                    className="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+                    className="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
                     onClick={() => signIn('google')}
                 >
                     Get started
                 </button>
+            </div>
+            <div className="md:w-1/2">
+                <Image
+                    src="/demo.gif"
+                    alt="Smart Recipe Generator demo"
+                    width={600}
+                    height={400}
+                    className="rounded-xl shadow-xl"
+                />
             </div>
         </div>
     );

--- a/src/components/Hero_Sections/Product.tsx
+++ b/src/components/Hero_Sections/Product.tsx
@@ -1,37 +1,58 @@
 
-import { CheckCircleIcon } from '@heroicons/react/24/solid'
+import { signIn } from 'next-auth/react';
+import Image from 'next/image';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 
 export default function Product({ resetPage }: { resetPage: () => void }) {
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp">
-      <h1 className="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center">Our Product</h1>
-      <h2 className="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl">
-        Learn more about the amazing features of our product.
-      </h2>
-      <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400">
-        <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          AI-powered recipe generation using your available ingredients.
-        </li>
-        <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Customized recipes based on dietary preferences and restrictions.
-        </li>
-        <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          User-friendly interface to easily add ingredients and generate recipes.
-        </li>
-        <li className="flex items-center text-lg">
-          <CheckCircleIcon className="block mr-2 h-6 w-6 text-brand-500" />
-          Option to save, rate, and share your favorite recipes.
-        </li>
-      </ul>
-      <button
-        className="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
-        onClick={resetPage}
-      >
-        Back to Home
-      </button>
+    <div className="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20">
+      <div className="flex flex-col items-center text-center md:items-start md:w-1/2 md:text-left space-y-6">
+        <h1 className="text-4xl font-semibold text-gray-900 dark:text-white">Our Product</h1>
+        <p className="text-lg leading-8 text-gray-600">
+          Learn how Smart Recipe Generator makes meal planning effortless.
+        </p>
+        <ul className="space-y-4 text-gray-500 list-inside dark:text-gray-400 text-left">
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            AI-powered recipe generation using your available ingredients.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Customized recipes based on dietary preferences and restrictions.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            User-friendly interface to easily add ingredients and generate recipes.
+          </li>
+          <li className="flex items-start text-lg">
+            <CheckCircleIcon className="mr-2 h-6 w-6 text-brand-500" />
+            Option to save, rate, and share your favorite recipes.
+          </li>
+        </ul>
+        <div className="flex gap-4">
+          <button
+            className="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+            onClick={() => signIn('google')}
+          >
+            Get started
+          </button>
+          <button
+            className="w-fit rounded-md bg-gray-200 px-5 py-3 text-base font-semibold text-gray-900 transition hover:bg-gray-300"
+            onClick={resetPage}
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+      <div className="md:w-1/2">
+        <Image
+          src="/demo.gif"
+          alt="Smart Recipe Generator demo"
+          width={600}
+          height={400}
+          className="rounded-xl shadow-xl"
+        />
+      </div>
     </div>
   );
 }

--- a/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Features.test.tsx.snap
@@ -3,103 +3,132 @@
 exports[`The Features section renders 1`] = `
 <div>
   <div
-    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp"
+    class="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20"
   >
-    <h1
-      class="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center"
+    <div
+      class="flex flex-col items-center text-center md:items-start md:w-1/2 md:text-left space-y-6"
     >
-      Features
-    </h1>
-    <h2
-      class="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl"
+      <h1
+        class="text-4xl font-semibold text-gray-900 dark:text-white"
+      >
+        Features
+      </h1>
+      <p
+        class="text-lg leading-8 text-gray-600"
+      >
+        Explore what makes Smart Recipe Generator unique.
+      </p>
+      <ul
+        class="space-y-4 text-gray-500 list-inside dark:text-gray-400 text-left"
+      >
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Ingredient-based recipe generation using advanced AI algorithms.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Support for various dietary preferences like vegan, gluten-free, and more.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Easy-to-use interface for adding ingredients and generating recipes.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Save, rate, and share your favorite recipes with others.
+        </li>
+      </ul>
+      <div
+        class="flex gap-4"
+      >
+        <button
+          class="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+        >
+          Get started
+        </button>
+        <button
+          class="w-fit rounded-md bg-gray-200 px-5 py-3 text-base font-semibold text-gray-900 transition hover:bg-gray-300"
+        >
+          Back to Home
+        </button>
+      </div>
+    </div>
+    <div
+      class="md:w-1/2"
     >
-      Discover the features that make our product unique.
-    </h2>
-    <ul
-      class="space-y-4 text-gray-500 list-inside dark:text-gray-400"
-    >
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Ingredient-based recipe generation using advanced AI algorithms.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Support for various dietary preferences like vegan, gluten-free, and more.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Easy-to-use interface for adding ingredients and generating recipes.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Save, rate, and share your favorite recipes with others.
-      </li>
-    </ul>
-    <button
-      class="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
-    >
-      Back to Home
-    </button>
+      <img
+        alt="Smart Recipe Generator demo"
+        class="rounded-xl shadow-xl"
+        data-nimg="1"
+        decoding="async"
+        height="400"
+        loading="lazy"
+        src="/_next/image?url=%2Fdemo.gif&w=1200&q=75"
+        srcset="/_next/image?url=%2Fdemo.gif&w=640&q=75 1x, /_next/image?url=%2Fdemo.gif&w=1200&q=75 2x"
+        style="color: transparent;"
+        width="600"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Landing.test.tsx.snap
@@ -3,26 +3,42 @@
 exports[`The Landing section renders 1`] = `
 <div>
   <div
-    class="text-center animate-fadeInUp"
+    class="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20"
   >
-    <h1
-      class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl"
-    >
-      Generate Delicious Recipes with Your Ingredients
-    </h1>
-    <p
-      class="mt-6 text-lg leading-8 text-gray-600"
-    >
-      Simply input your available ingredients, select dietary preferences, and let our AI create unique and delicious recipes just for you.
-    </p>
     <div
-      class="mt-10 flex items-center justify-center gap-x-6"
+      class="flex flex-col items-center text-center md:items-start md:text-left md:w-1/2 space-y-6"
     >
+      <h1
+        class="text-5xl font-extrabold tracking-tight text-gray-900"
+      >
+        Cook Smarter with AI
+      </h1>
+      <p
+        class="text-lg leading-8 text-gray-600"
+      >
+        Drop in the ingredients you have on hand and let our AI whip up creative recipes tailored to your dietary needs.
+      </p>
       <button
-        class="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+        class="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
       >
         Get started
       </button>
+    </div>
+    <div
+      class="md:w-1/2"
+    >
+      <img
+        alt="Smart Recipe Generator demo"
+        class="rounded-xl shadow-xl"
+        data-nimg="1"
+        decoding="async"
+        height="400"
+        loading="lazy"
+        src="/_next/image?url=%2Fdemo.gif&w=1200&q=75"
+        srcset="/_next/image?url=%2Fdemo.gif&w=640&q=75 1x, /_next/image?url=%2Fdemo.gif&w=1200&q=75 2x"
+        style="color: transparent;"
+        width="600"
+      />
     </div>
   </div>
 </div>

--- a/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
+++ b/tests/components/Hero_Sections/__snapshots__/Product.test.tsx.snap
@@ -3,103 +3,132 @@
 exports[`The Product section renders 1`] = `
 <div>
   <div
-    class="flex flex-col justify-center items-center px-4 md:px-8 lg:px-12 animate-fadeInUp"
+    class="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20"
   >
-    <h1
-      class="mb-2 text-4xl font-semibold text-gray-900 dark:text-white text-center"
+    <div
+      class="flex flex-col items-center text-center md:items-start md:w-1/2 md:text-left space-y-6"
     >
-      Our Product
-    </h1>
-    <h2
-      class="mt-6 mb-5 text-2xl leading-8 text-gray-600 text-center max-w-2xl"
+      <h1
+        class="text-4xl font-semibold text-gray-900 dark:text-white"
+      >
+        Our Product
+      </h1>
+      <p
+        class="text-lg leading-8 text-gray-600"
+      >
+        Learn how Smart Recipe Generator makes meal planning effortless.
+      </p>
+      <ul
+        class="space-y-4 text-gray-500 list-inside dark:text-gray-400 text-left"
+      >
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          AI-powered recipe generation using your available ingredients.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Customized recipes based on dietary preferences and restrictions.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          User-friendly interface to easily add ingredients and generate recipes.
+        </li>
+        <li
+          class="flex items-start text-lg"
+        >
+          <svg
+            aria-hidden="true"
+            class="mr-2 h-6 w-6 text-brand-500"
+            data-slot="icon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
+              fill-rule="evenodd"
+            />
+          </svg>
+          Option to save, rate, and share your favorite recipes.
+        </li>
+      </ul>
+      <div
+        class="flex gap-4"
+      >
+        <button
+          class="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+        >
+          Get started
+        </button>
+        <button
+          class="w-fit rounded-md bg-gray-200 px-5 py-3 text-base font-semibold text-gray-900 transition hover:bg-gray-300"
+        >
+          Back to Home
+        </button>
+      </div>
+    </div>
+    <div
+      class="md:w-1/2"
     >
-      Learn more about the amazing features of our product.
-    </h2>
-    <ul
-      class="space-y-4 text-gray-500 list-inside dark:text-gray-400"
-    >
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        AI-powered recipe generation using your available ingredients.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Customized recipes based on dietary preferences and restrictions.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        User-friendly interface to easily add ingredients and generate recipes.
-      </li>
-      <li
-        class="flex items-center text-lg"
-      >
-        <svg
-          aria-hidden="true"
-          class="block mr-2 h-6 w-6 text-brand-500"
-          data-slot="icon"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        Option to save, rate, and share your favorite recipes.
-      </li>
-    </ul>
-    <button
-      class="mt-10 rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
-    >
-      Back to Home
-    </button>
+      <img
+        alt="Smart Recipe Generator demo"
+        class="rounded-xl shadow-xl"
+        data-nimg="1"
+        decoding="async"
+        height="400"
+        loading="lazy"
+        src="/_next/image?url=%2Fdemo.gif&w=1200&q=75"
+        srcset="/_next/image?url=%2Fdemo.gif&w=640&q=75 1x, /_next/image?url=%2Fdemo.gif&w=1200&q=75 2x"
+        style="color: transparent;"
+        width="600"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/__snapshots__/Layout.test.tsx.snap
+++ b/tests/components/__snapshots__/Layout.test.tsx.snap
@@ -164,26 +164,42 @@ exports[`The Layout renders the hero if the user is not authenticated 1`] = `
           </div>
         </div>
         <div
-          class="text-center animate-fadeInUp"
+          class="animate-fadeInUp mx-auto flex max-w-4xl flex-col items-center gap-10 py-10 md:flex-row md:py-20"
         >
-          <h1
-            class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl"
-          >
-            Generate Delicious Recipes with Your Ingredients
-          </h1>
-          <p
-            class="mt-6 text-lg leading-8 text-gray-600"
-          >
-            Simply input your available ingredients, select dietary preferences, and let our AI create unique and delicious recipes just for you.
-          </p>
           <div
-            class="mt-10 flex items-center justify-center gap-x-6"
+            class="flex flex-col items-center text-center md:items-start md:text-left md:w-1/2 space-y-6"
           >
+            <h1
+              class="text-5xl font-extrabold tracking-tight text-gray-900"
+            >
+              Cook Smarter with AI
+            </h1>
+            <p
+              class="text-lg leading-8 text-gray-600"
+            >
+              Drop in the ingredients you have on hand and let our AI whip up creative recipes tailored to your dietary needs.
+            </p>
             <button
-              class="rounded-md bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+              class="w-fit rounded-md bg-brand-600 px-5 py-3 text-base font-semibold text-white shadow-md transition hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
             >
               Get started
             </button>
+          </div>
+          <div
+            class="md:w-1/2"
+          >
+            <img
+              alt="Smart Recipe Generator demo"
+              class="rounded-xl shadow-xl"
+              data-nimg="1"
+              decoding="async"
+              height="400"
+              loading="lazy"
+              src="/_next/image?url=%2Fdemo.gif&w=1200&q=75"
+              srcset="/_next/image?url=%2Fdemo.gif&w=640&q=75 1x, /_next/image?url=%2Fdemo.gif&w=1200&q=75 2x"
+              style="color: transparent;"
+              width="600"
+            />
           </div>
         </div>
       </div>

--- a/tests/pages/Hero.test.tsx
+++ b/tests/pages/Hero.test.tsx
@@ -37,11 +37,11 @@ describe("The Hero Component",()=>{
         render(<Hero/>)
         const feature = await screen.findByText('Features')
         fireEvent.click(feature);
-        let featureComponent: any = await screen.findByText('Discover the features that make our product unique.')
+        let featureComponent: any = await screen.findByText('Explore what makes Smart Recipe Generator unique.')
         expect(featureComponent).toBeInTheDocument();
         const backHomeButton = await screen.findByText('Back to Home')
         fireEvent.click(backHomeButton);
-        featureComponent = await screen.queryByText('Discover the features that make our product unique.')
+        featureComponent = await screen.queryByText('Explore what makes Smart Recipe Generator unique.')
         expect(featureComponent).toBeNull()
     })
 


### PR DESCRIPTION
## What changed & why
- updated landing hero with 2-column layout and demo gif
- adjusted E2E test for new copy
- updated Jest snapshots

## How to test locally
```bash
npm run compileTS
npm run lint
npm run all_tests
npm run coverage # optional
npm run test:e2e
```

The landing page now shows a modern hero inviting users to log in.

------
https://chatgpt.com/codex/tasks/task_e_684b3656d374832ba832a538d0e1b658