### PR TITLE
[api] use query param for delete recipe

### DIFF
--- a/cypress/e2e/recipeCardActions.cy.ts
+++ b/cypress/e2e/recipeCardActions.cy.ts
@@ -159,7 +159,7 @@ describe('Recipe Card Actions', () => {
 
       const first = recipes[0];
 
-      cy.intercept('DELETE', '/api/delete-recipe', {
+      cy.intercept('DELETE', `/api/delete-recipe?recipeId=${first._id}`, {
         statusCode: 200,
         body: { message: `Deleted recipe with id ${first._id}` },
       }).as('deleteRecipe');

--- a/docs/gpt-testing.md
+++ b/docs/gpt-testing.md
@@ -168,9 +168,8 @@ describe('useActionPopover', () => {
         });
 
         expect(call_api).toHaveBeenCalledWith({
-            address: '/api/delete-recipe',
+            address: `/api/delete-recipe?recipeId=123`,
             method: 'delete',
-            payload: { data: { recipeId: '123' } },
         });
         expect(response).toEqual({ success: true });
     });

--- a/src/components/Hooks/useActionPopover.ts
+++ b/src/components/Hooks/useActionPopover.ts
@@ -94,9 +94,8 @@ function useActionPopover(recipe: ExtendedRecipe | null, updateRecipe: (audioLin
     const handleDeleteRecipe = async () => {
         try {
             const response = await call_api({
-                address: '/api/delete-recipe',
-                method: 'delete',
-                payload: { data: { recipeId: recipe?._id } }
+                address: `/api/delete-recipe?recipeId=${recipe?._id}`,
+                method: 'delete'
             })
             return response;
         } catch (error) {

--- a/tests/components/Hooks/useActionPopover.test.ts
+++ b/tests/components/Hooks/useActionPopover.test.ts
@@ -134,9 +134,8 @@ describe('useActionPopover', () => {
         });
 
         expect(call_api).toHaveBeenCalledWith({
-            address: '/api/delete-recipe',
+            address: `/api/delete-recipe?recipeId=6683b8d38475eac9af5fe838`,
             method: 'delete',
-            payload: { data: { recipeId: '6683b8d38475eac9af5fe838' } },
         });
         expect(response).toEqual({ success: true });
     });

--- a/tests/components/Recipe_Display/ViewRecipes.test.tsx
+++ b/tests/components/Recipe_Display/ViewRecipes.test.tsx
@@ -83,9 +83,8 @@ describe('The view recipes component', () => {
         const deleteButton = await screen.findByText('Delete');
         fireEvent.click(deleteButton)
         expect(deleteApi).toHaveBeenCalledWith({
-            "address": "/api/delete-recipe",
-            "method": "delete",
-            "payload": { "data": { "recipeId": "6683b8d38475eac9af5fe838" } }
+            "address": `/api/delete-recipe?recipeId=6683b8d38475eac9af5fe838`,
+            "method": "delete"
         })
     })
 
@@ -113,9 +112,8 @@ describe('The view recipes component', () => {
         const deleteButton = await screen.findByText('Delete');
         fireEvent.click(deleteButton)
         expect(deleteApi).toHaveBeenCalledWith({
-            "address": "/api/delete-recipe",
-            "method": "delete",
-            "payload": { "data": { "recipeId": "6683b8d38475eac9af5fe838" } }
+            "address": `/api/delete-recipe?recipeId=6683b8d38475eac9af5fe838`,
+            "method": "delete"
         })
     })
 })

--- a/tests/pages/api/delete-recipe.test.ts
+++ b/tests/pages/api/delete-recipe.test.ts
@@ -61,12 +61,10 @@ describe('Deleting a recipe', () => {
         const { req, res } = mockRequestResponse('DELETE')
         const updatedreq: any = {
             ...req,
-            body: {
-                recipeId: 'invalid-recipe-id'
-            }
+            query: { recipeId: 'invalid-recipe-id' }
         }
         await deleteRecipe(updatedreq, res)
-        expect(res._getJSONData()).toEqual({ error: "Invalid recipe ID" })
+        expect(res._getJSONData()).toEqual({ error: 'Invalid recipe ID.' })
     })
 
     it('shall reject request if the recipe id is not found', async () => {
@@ -81,12 +79,10 @@ describe('Deleting a recipe', () => {
         const { req, res } = mockRequestResponse('DELETE')
         const updatedreq: any = {
             ...req,
-            body: {
-                recipeId: 1234
-            }
+            query: { recipeId: '648863e41f4500b3d9a3c1a9' }
         }
         await deleteRecipe(updatedreq, res)
-        expect(res._getJSONData()).toEqual({error: 'Recipe with Id: 1234 not found... exiting DELETE'})
+        expect(res._getJSONData()).toEqual({ error: 'Recipe with ID: 648863e41f4500b3d9a3c1a9 not found.' })
     })
 
     it('shall reject request if the recipe is not owned by the user', async () => {
@@ -101,12 +97,10 @@ describe('Deleting a recipe', () => {
         const { req, res } = mockRequestResponse('DELETE')
         const updatedreq: any = {
             ...req,
-            body: {
-                recipeId: 1234
-            }
+            query: { recipeId: '648863e41f4500b3d9a3c1a9' }
         }
         await deleteRecipe(updatedreq, res)
-        expect(res._getJSONData()).toEqual({error: 'Recipe with Id: 1234 is not owned by userId: 6687d83725254486590fec59... exiting DELETE'})
+        expect(res._getJSONData()).toEqual({ error: 'You do not have permission to delete this recipe.' })
     })
 
 
@@ -131,12 +125,10 @@ describe('Deleting a recipe', () => {
         const { req, res } = mockRequestResponse('DELETE')
         const updatedreq: any = {
             ...req,
-            body: {
-                recipeId: 1234
-            }
+            query: { recipeId: '648863e41f4500b3d9a3c1a9' }
         }
         await deleteRecipe(updatedreq, res)
-        expect(res._getJSONData()).toEqual({message: 'Deleted recipe with id 1234'})
+        expect(res._getJSONData()).toEqual({ message: 'Deleted recipe with ID 648863e41f4500b3d9a3c1a9' })
     })
 
     it('will respond with error if DELETE call is rejected', async () => {
@@ -151,9 +143,7 @@ describe('Deleting a recipe', () => {
         const { req, res } = mockRequestResponse('DELETE')
         const updatedreq: any = {
             ...req,
-            body: {
-                recipeId: 1234
-            }
+            query: { recipeId: '648863e41f4500b3d9a3c1a9' }
         }
         await deleteRecipe(updatedreq, res)
         expect(res.statusCode).toBe(500)


### PR DESCRIPTION
## What changed & why
- restored `delete-recipe` endpoint and now read `recipeId` from the query string
- updated client hook and tests to send `/api/delete-recipe?recipeId=<id>`
- removed dynamic `[recipeId]` route
- refreshed docs and Cypress spec

## How to test locally
```bash
npm run compileTS
npm run lint
npm run all_tests
npm run test:e2e
```


------
https://chatgpt.com/codex/tasks/task_e_684d1ffd5060832bba9fc7d3e4487825