### PR TITLE
[openai] migrate recipe image generation to GPT Image model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/github/license/Dereje1/smart-recipe-generator)
 ![Vercel Deployment](https://img.shields.io/badge/Deployed%20on-Vercel-green)
 
-**Smart Recipe Generator** is an **AI-powered web application** that uses **GPT-4** to generate unique recipes based on selected ingredients and dietary preferences, **DALL·E** to create custom recipe images, and **TTS** to narrate recipes. It's designed to make cooking easy, creative, and accessible for everyone.
+**Smart Recipe Generator** is an **AI-powered web application** that uses **GPT-4** to generate unique recipes based on selected ingredients and dietary preferences, **OpenAI GPT Image** to create custom recipe images (default: `gpt-image-1`), and **TTS** to narrate recipes. It's designed to make cooking easy, creative, and accessible for everyone.
 
 🎥 **App Demo**
 
@@ -20,7 +20,7 @@
 
 ### 🤖 **AI-Powered Features**
 - **GPT-4 Recipe Generation**: Create unique recipes based on user-selected ingredients and dietary preferences.
-- **DALL·E Image Generation**: Automatically generate high-quality images of the recipes.
+- **OpenAI GPT Image Generation**: Automatically generate high-quality images of the recipes (default model: `gpt-image-1`).
 - **Text-to-Speech (TTS)**: Narrate recipes aloud using AI-driven speech synthesis.
 - **AI-Generated Tags**: Recipes are automatically tagged with relevant keywords for better searchability.
 - **Context-Aware Chat Assistant**: Ask cooking-related questions about a recipe (e.g., substitutions, vegan options, prep time). Powered by GPT-4, limited to the context of each recipe.
@@ -42,7 +42,7 @@
 
 - **Frontend**: Next.js, React, Tailwind CSS
 - **Backend**: Node.js, MongoDB
-- **AI Integration**: OpenAI GPT-4 for recipes, DALL·E for images, TTS for narration
+- **AI Integration**: OpenAI GPT-4 for recipes, OpenAI GPT Image for images, TTS for narration
 - **Authentication**: NextAuth.js with Google OAuth
 - **Cloud Storage**: AWS S3 for storing images and audio
 - **Deployment**: Vercel
@@ -71,6 +71,7 @@ NEXTAUTH_SECRET=your-secret
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_IMAGE_MODEL=gpt-image-1
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 MONGO_URI=your-mongodb-uri

--- a/src/lib/awss3.ts
+++ b/src/lib/awss3.ts
@@ -6,7 +6,8 @@ import { UploadReturnType } from '../types';
 
 // Define an interface for the upload parameters
 interface UploadToS3Type {
-    originalImgLink: string | undefined;
+    originalImgLink?: string;
+    imageBuffer?: Buffer;
     userId: string | undefined;
     location: string;
 }
@@ -80,10 +81,51 @@ export const uploadImageToS3 = async ({
     }
 };
 
+
+
+export const uploadImageBufferToS3 = async ({
+    imageBuffer,
+    userId,
+    location
+}: {
+    imageBuffer: Buffer;
+    userId: string | undefined;
+    location: string;
+}): Promise<UploadReturnType> => {
+    try {
+        const s3 = configureS3();
+        if (!s3) throw new Error('Unable to configure S3');
+
+        const command = new PutObjectCommand({
+            Bucket: process.env.S3_BUCKET_NAME || '',
+            Key: location,
+            Body: imageBuffer,
+            ContentType: 'image/png',
+            Tagging: `userId=${userId}`,
+            CacheControl: "public, max-age=2592000",
+        });
+        await s3.send(command);
+        return {
+            location,
+            uploaded: true
+        };
+    } catch (error) {
+        console.error(`Error uploading image buffer. ${location} - ${error}`);
+        return {
+            location,
+            uploaded: false
+        };
+    }
+};
 // Function to upload multiple images to S3
 export const uploadImagesToS3 = async (openaiImagesArray: UploadToS3Type[]): Promise<UploadReturnType[] | null> => {
     try {
-        const imagePromises: Promise<UploadReturnType>[] = openaiImagesArray.map(img => uploadImageToS3(img));
+        const imagePromises: Promise<UploadReturnType>[] = openaiImagesArray.map(img => {
+            if (img.imageBuffer) {
+                return uploadImageBufferToS3({ imageBuffer: img.imageBuffer, userId: img.userId, location: img.location });
+            }
+            return uploadImageToS3(img);
+        });
         const results = await Promise.all(imagePromises);
         return results;
     } catch (error) {

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -82,31 +82,40 @@ const generateImage = (prompt: string, model: string): Promise<ImagesResponse> =
     }
 };
 
+const OPENAI_IMAGE_MODEL = process.env.OPENAI_IMAGE_MODEL || 'gpt-image-1';
+
 // Generate images for an array of recipes and return image links paired with recipe names
 export const generateImages = async (recipes: Recipe[], userId: string) => {
     try {
-        const model = 'dall-e-3';
+        const model = OPENAI_IMAGE_MODEL;
         const imagePromises: Promise<ImagesResponse>[] = recipes.map(recipe =>
             generateImage(getImageGenerationPrompt(recipe.name, recipe.ingredients), model)
         );
         const images = await Promise.all(imagePromises);
+        const imageLogSummary = images.map((imageResponse) => ({
+            created: imageResponse.created,
+            hasUrl: Boolean(imageResponse?.data?.[0]?.url),
+            hasB64Json: Boolean(imageResponse?.data?.[0]?.b64_json),
+        }));
         await saveOpenaiResponses({
             userId,
             prompt: `Image generation for recipe names ${recipes.map(r => r.name).join(' ,')} (note: not exact prompt)`,
-            response: images,
+            response: imageLogSummary,
             model
         });
         // Validate and map images safely
         const imagesWithNames = images.map((imageResponse, idx) => {
             const recipeName = recipes[idx].name;
-            const url = imageResponse?.data?.[0]?.url;
+            const imageData = imageResponse?.data?.[0];
+            const url = imageData?.url;
+            const b64Json = imageData?.b64_json;
 
-            if (!url) {
+            if (!b64Json && !url) {
                 throw new Error(`Image generation failed for recipe: ${recipeName}`);
             }
 
             return {
-                imgLink: url,
+                imgLink: b64Json ? `data:image/png;base64,${b64Json}` : url as string,
                 name: recipeName,
             };
         });

--- a/src/pages/api/save-recipes.ts
+++ b/src/pages/api/save-recipes.ts
@@ -39,11 +39,18 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, session: any) 
         const imageResults = await generateImages(recipeNames, session.user.id);
         
         // Prepare images for uploading to S3
-        const openaiImagesArray = imageResults.map((result, idx) => ({
-            originalImgLink: result.imgLink,
-            userId: session.user.id,
-            location: recipes[idx].openaiPromptId
-        }));
+        const openaiImagesArray = imageResults.map((result, idx) => {
+            const dataUriPrefix = 'data:image/png;base64,';
+            const isBase64DataUri = result.imgLink?.startsWith(dataUriPrefix);
+            const b64Data = isBase64DataUri ? result.imgLink.slice(dataUriPrefix.length) : '';
+
+            return {
+                originalImgLink: isBase64DataUri ? undefined : result.imgLink,
+                imageBuffer: isBase64DataUri ? Buffer.from(b64Data, 'base64') : undefined,
+                userId: session.user.id,
+                location: recipes[idx].openaiPromptId
+            };
+        });
 
         // Upload images to S3
         console.info('Uploading OpenAI images to S3...');

--- a/tests/lib/awss3.test.ts
+++ b/tests/lib/awss3.test.ts
@@ -81,8 +81,6 @@ describe('Uploading images to S3', () => {
         ]);
     });
 
-    
-
     it('will upload an image buffer to S3 successfully', async () => {
         const result = await uploadImageBufferToS3({
             imageBuffer: Buffer.from('buffer-image-data'),
@@ -102,7 +100,8 @@ describe('Uploading images to S3', () => {
 
         expect(result).toEqual({ location: 'buffer-location-1', uploaded: true });
     });
-it('will handle failures in processing images', async () => {
+
+    it('will handle failures in processing images', async () => {
         // Clean existing mocks and set new erroneous endpoints
         nock.cleanAll();
         nock('https://openai-img-link-3')

--- a/tests/lib/awss3.test.ts
+++ b/tests/lib/awss3.test.ts
@@ -4,7 +4,7 @@
 import nock from 'nock';
 import { S3Client } from '@aws-sdk/client-s3';
 import { mockClient } from 'aws-sdk-client-mock';
-import { uploadImagesToS3, uploadAudioToS3 } from "../../src/lib/awss3";
+import { uploadImagesToS3, uploadAudioToS3, uploadImageBufferToS3 } from "../../src/lib/awss3";
 
 describe('Uploading images to S3', () => {
     let mockS3Client: any;
@@ -81,7 +81,28 @@ describe('Uploading images to S3', () => {
         ]);
     });
 
-    it('will handle failures in processing images', async () => {
+    
+
+    it('will upload an image buffer to S3 successfully', async () => {
+        const result = await uploadImageBufferToS3({
+            imageBuffer: Buffer.from('buffer-image-data'),
+            userId: 'mockUserId',
+            location: 'buffer-location-1'
+        });
+
+        const [params1] = mockS3Client.send.args;
+        expect(params1[0].input).toEqual({
+            Bucket: 'stub-bucket-name',
+            Key: 'buffer-location-1',
+            Body: Buffer.from('buffer-image-data'),
+            ContentType: 'image/png',
+            Tagging: 'userId=mockUserId',
+            CacheControl: "public, max-age=2592000",
+        });
+
+        expect(result).toEqual({ location: 'buffer-location-1', uploaded: true });
+    });
+it('will handle failures in processing images', async () => {
         // Clean existing mocks and set new erroneous endpoints
         nock.cleanAll();
         nock('https://openai-img-link-3')

--- a/tests/lib/openai.test.ts
+++ b/tests/lib/openai.test.ts
@@ -160,15 +160,15 @@ describe('generating images of recipes from open ai', () => {
     });
     it('shall generate images given ingredients', async () => {
         // mock opena ai chat completion
-        openai.images.generate = jest.fn().mockImplementation(() => Promise.resolve({ data: [{ url: 'http:/stub-ai-image-url' }] }))
+        openai.images.generate = jest.fn().mockImplementation(() => Promise.resolve({ data: [{ b64_json: Buffer.from('stub-ai-image').toString('base64') }] }))
         // mock db create query
         aigenerated.create = jest.fn().mockImplementation(
             () => Promise.resolve({ _id: 1234 }),
         );
         const result = await generateImages(stubRecipeBatch, 'mockUserId')
         expect(result).toEqual([
-            { imgLink: 'http:/stub-ai-image-url', name: 'Recipe_1_name' },
-            { imgLink: 'http:/stub-ai-image-url', name: 'Recipe_2_name' }
+            { imgLink: `data:image/png;base64,${Buffer.from('stub-ai-image').toString('base64')}`, name: 'Recipe_1_name' },
+            { imgLink: `data:image/png;base64,${Buffer.from('stub-ai-image').toString('base64')}`, name: 'Recipe_2_name' }
         ])
         const normalizeWhitespace = (str: string) => str.replace(/\s+/g, ' ').trim();
 
@@ -178,11 +178,17 @@ describe('generating images of recipes from open ai', () => {
         call.prompt = normalizeWhitespace(call.prompt); // Normalize the received prompt
 
         expect(call).toEqual({
-            model: "dall-e-3",
+            model: process.env.OPENAI_IMAGE_MODEL || "gpt-image-1",
             n: 1,
             prompt: expectedPrompt,
             size: "1024x1024",
         });
+    })
+
+
+    it('shall throw error if openai image payload has neither url nor b64_json', async () => {
+        openai.images.generate = jest.fn().mockImplementation(() => Promise.resolve({ data: [{}] }))
+        await expect(generateImages(stubRecipeBatch, 'mockUserId')).rejects.toEqual(new Error('Failed to generate image'))
     })
 
     it('shall throw error if openai can not respond with image', async () => {


### PR DESCRIPTION
### Motivation
- Replace deprecated hardcoded `dall-e-3` usage with a configurable GPT Image model and handle GPT Image output shape which returns base64 data instead of a URL.
- Preserve the public image contract `{ imgLink: string; name: string }` and ensure stored `imgLink` remains an S3 URL so the app requires no UI changes.

### Description
- Add `OPENAI_IMAGE_MODEL` with fallback `gpt-image-1` and use it for image generation instead of `dall-e-3`.
- Read `b64_json` from OpenAI image responses and produce a data URI (`data:image/png;base64,...`) when present, falling back to legacy `url` if available, and sanitize logging by saving only response metadata.
- Add `uploadImageBufferToS3(...)` and update `uploadImagesToS3(...)` to route to buffer upload when an image `Buffer` is provided while preserving the existing URL-download upload path.
- Detect base64 data-URIs in `save-recipes` (convert to `Buffer.from(..., 'base64')`) and pass `imageBuffer` into the existing S3 upload flow so final saved recipes continue referencing S3-hosted images; Closes #42.

### Testing
- Updated and ran focused tests: `tests/lib/openai.test.ts` and `tests/lib/awss3.test.ts` with `npm test -- --runInBand tests/lib/openai.test.ts tests/lib/awss3.test.ts` and both suites passed.
- Test result summary: 2 test suites passed, 21 tests passed (suites: `openai.test`, `awss3.test`).
- Tests verify: OpenAI image call uses env/default GPT Image model, `b64_json` handling and error when neither `url` nor `b64_json` exist, and S3 buffer upload behavior for image buffers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32f0e31f0832baf3908c57cd52e48)