### PR TITLE
[api] Harden /api/validate-ingredient input, duplicate detection, and OpenAI parsing

### DIFF
--- a/src/pages/api/validate-ingredient.ts
+++ b/src/pages/api/validate-ingredient.ts
@@ -3,6 +3,53 @@ import { apiMiddleware } from '../../lib/apiMiddleware';
 import { validateIngredient } from '../../lib/openai';
 import Ingredient from '../../models/ingredient';
 import mongoose from 'mongoose';
+import pluralize from 'pluralize';
+
+const MAX_INGREDIENT_NAME_LENGTH = 20;
+
+const normalizeIngredientName = (value: string) => value.trim().toLowerCase();
+
+const parseValidationResponse = (
+    response: string | null
+): { isValid: boolean; possibleVariations: string[] } | null => {
+    if (!response) return null;
+
+    const sanitizedResponse = response
+        .trim()
+        .replace(/^```(?:json)?\s*/i, '')
+        .replace(/\s*```$/, '');
+
+    try {
+        const parsed: unknown = JSON.parse(sanitizedResponse);
+        if (!parsed || typeof parsed !== 'object') {
+            return null;
+        }
+        const parsedRecord = parsed as Record<string, unknown>;
+        if (typeof parsedRecord.isValid !== 'boolean') return null;
+
+        const possibleVariations = Array.isArray(parsedRecord.possibleVariations)
+            ? parsedRecord.possibleVariations.filter((variation: unknown): variation is string => typeof variation === 'string')
+            : [];
+
+        return {
+            isValid: parsedRecord.isValid,
+            possibleVariations
+        };
+    } catch (error) {
+        console.error('Failed to parse OpenAI ingredient validation response', error);
+        return null;
+    }
+};
+
+const isDuplicateIngredient = (ingredientName: string, existingName: string) => {
+    const normalizedIngredient = normalizeIngredientName(ingredientName);
+    const normalizedExisting = normalizeIngredientName(existingName);
+
+    return (
+        normalizedIngredient === normalizedExisting ||
+        pluralize.singular(normalizedIngredient) === pluralize.singular(normalizedExisting)
+    );
+};
 
 /**
  * API handler for validating and adding a new ingredient.
@@ -14,20 +61,27 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, session: any) 
         // Extract ingredient name from the request body
         const { ingredientName } = req.body;
         const userId = session.user.id;
+        const trimmedIngredientName = typeof ingredientName === 'string' ? ingredientName.trim() : '';
 
         // Validate ingredient name input
-        if (!ingredientName) {
+        if (!trimmedIngredientName) {
             return res.status(400).json({ error: 'Ingredient name is required' });
+        }
+        if (trimmedIngredientName.length > MAX_INGREDIENT_NAME_LENGTH) {
+            return res.status(400).json({ error: `Ingredient name cannot exceed ${MAX_INGREDIENT_NAME_LENGTH} characters` });
         }
 
         // Validate ingredient using OpenAI
         console.info('Validating ingredient from OpenAI...');
-        const response = await validateIngredient(ingredientName, userId);
-        const parsedResponse = response ? JSON.parse(response) : null;
+        const response = await validateIngredient(trimmedIngredientName, userId);
+        const parsedResponse = parseValidationResponse(response);
 
         if (parsedResponse) {
-            const formattedIngredientName = ingredientName[0].toUpperCase() + ingredientName.slice(1).toLowerCase();
-            const ingredientExists = await Ingredient.findOne({ name: formattedIngredientName });
+            const formattedIngredientName = trimmedIngredientName[0].toUpperCase() + trimmedIngredientName.slice(1).toLowerCase();
+            const allIngredients = await Ingredient.find({}, { name: 1 });
+            const ingredientExists = allIngredients.find((ingredient: { name: string }) =>
+                isDuplicateIngredient(formattedIngredientName, ingredient.name)
+            );
 
             if (parsedResponse.isValid) {
                 if (!ingredientExists) {

--- a/src/pages/api/validate-ingredient.ts
+++ b/src/pages/api/validate-ingredient.ts
@@ -71,36 +71,35 @@ const handler = async (req: NextApiRequest, res: NextApiResponse, session: any) 
             return res.status(400).json({ error: `Ingredient name cannot exceed ${MAX_INGREDIENT_NAME_LENGTH} characters` });
         }
 
+        const formattedIngredientName = trimmedIngredientName[0].toUpperCase() + trimmedIngredientName.slice(1).toLowerCase();
+        const allIngredients = await Ingredient.find({}, { name: 1 });
+        const ingredientExists = allIngredients.find((ingredient: { name: string }) =>
+            isDuplicateIngredient(formattedIngredientName, ingredient.name)
+        );
+
+        if (ingredientExists) {
+            return res.status(200).json({
+                message: 'Error: This ingredient already exists'
+            });
+        }
+
         // Validate ingredient using OpenAI
         console.info('Validating ingredient from OpenAI...');
         const response = await validateIngredient(trimmedIngredientName, userId);
         const parsedResponse = parseValidationResponse(response);
 
         if (parsedResponse) {
-            const formattedIngredientName = trimmedIngredientName[0].toUpperCase() + trimmedIngredientName.slice(1).toLowerCase();
-            const allIngredients = await Ingredient.find({}, { name: 1 });
-            const ingredientExists = allIngredients.find((ingredient: { name: string }) =>
-                isDuplicateIngredient(formattedIngredientName, ingredient.name)
-            );
-
             if (parsedResponse.isValid) {
-                if (!ingredientExists) {
-                    // Create new ingredient if it does not exist
-                    const newIngredient = await Ingredient.create({
-                        name: formattedIngredientName,
-                        createdBy: new mongoose.Types.ObjectId(userId)
-                    });
-                    return res.status(200).json({
-                        message: 'Success',
-                        newIngredient,
-                        suggested: parsedResponse.possibleVariations
-                    });
-                } else {
-                    // Respond with error if ingredient already exists
-                    return res.status(200).json({
-                        message: 'Error: This ingredient already exists'
-                    });
-                }
+                // Create new ingredient if it does not exist
+                const newIngredient = await Ingredient.create({
+                    name: formattedIngredientName,
+                    createdBy: new mongoose.Types.ObjectId(userId)
+                });
+                return res.status(200).json({
+                    message: 'Success',
+                    newIngredient,
+                    suggested: parsedResponse.possibleVariations
+                });
             } else {
                 // Respond with invalid ingredient and possible variations
                 return res.status(200).json({

--- a/tests/pages/api/validate-ingredient.test.ts
+++ b/tests/pages/api/validate-ingredient.test.ts
@@ -281,6 +281,9 @@ describe('/api/validate-ingredient', () => {
     it('will respond with error if POST call is rejected', async () => {
         getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
         validateIngredientSpy.mockRejectedValueOnce(() => Promise.reject())
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
+        );
 
         const { req, res } = mockRequestResponse('POST')
         const updatedreq: any = {

--- a/tests/pages/api/validate-ingredient.test.ts
+++ b/tests/pages/api/validate-ingredient.test.ts
@@ -30,7 +30,7 @@ jest.mock('../../../src/lib/openai', () => ({
     validateIngredient: jest.fn(() => Promise.resolve(null))
 }))
 
-describe('Liking a recipe', () => {
+describe('/api/validate-ingredient', () => {
     let getServerSessionSpy: any
     let validateIngredientSpy: any
     beforeEach(() => {
@@ -87,6 +87,24 @@ describe('Liking a recipe', () => {
         expect(res._getJSONData()).toEqual({ message: 'Error with parsing response' })
     })
 
+    it('shall reject whitespace-only ingredient names', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: '   ' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(400)
+        expect(res._getJSONData()).toEqual({ error: 'Ingredient name is required' })
+    })
+
+    it('shall reject ingredient names longer than 20 characters after trimming', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: '  thisingredientnameistoolong  ' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(400)
+        expect(res._getJSONData()).toEqual({ error: 'Ingredient name cannot exceed 20 characters' })
+    })
+
     it('shall appropriately respond for an invalid ingredient name ', async () => {
         getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
         // change open ai result
@@ -95,7 +113,7 @@ describe('Liking a recipe', () => {
             possibleVariations: ['var-1', 'var-2']
         })))
         // mock db find query
-        Ingredient.findOne = jest.fn().mockImplementation(
+        Ingredient.find = jest.fn().mockImplementation(
             () => Promise.resolve([]),
         );
         const { req, res } = mockRequestResponse('POST')
@@ -118,8 +136,8 @@ describe('Liking a recipe', () => {
             possibleVariations: ['var-1', 'var-2']
         })))
         // mock db find query
-        Ingredient.findOne = jest.fn().mockImplementation(
-            () => Promise.resolve(true),
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([{ name: 'Mockingredient' }]),
         );
         const { req, res } = mockRequestResponse('POST')
         const updatedreq: any = {
@@ -133,6 +151,54 @@ describe('Liking a recipe', () => {
         expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
     })
 
+    it('shall detect case-insensitive existing ingredients', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve(JSON.stringify({
+            isValid: true,
+            possibleVariations: []
+        })))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([{ name: 'Tomato' }]),
+        );
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: 'tomato' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+    })
+
+    it('shall detect singular and plural duplicate ingredients', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve(JSON.stringify({
+            isValid: true,
+            possibleVariations: []
+        })))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([{ name: 'tomatoes' }]),
+        );
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: 'tomato' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+    })
+
+    it('shall detect duplicates when incoming ingredient has padded whitespace', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve(JSON.stringify({
+            isValid: true,
+            possibleVariations: []
+        })))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([{ name: 'tomato' }]),
+        );
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: '  tomato  ' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+    })
+
     it('shall add the requested ingredient if valid and does not exist in the db', async () => {
         getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
         // change open ai result
@@ -141,8 +207,8 @@ describe('Liking a recipe', () => {
             possibleVariations: ['var-1', 'var-2']
         })))
         // mock db find query
-        Ingredient.findOne = jest.fn().mockImplementation(
-            () => Promise.resolve(false),
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
         );
         // mock db create query
         Ingredient.create = jest.fn().mockImplementation(
@@ -158,6 +224,48 @@ describe('Liking a recipe', () => {
         await validateIngredient(updatedreq, res)
         expect(res.statusCode).toBe(200)
         expect(res._getJSONData()).toEqual({ message: 'Success', newIngredient: 'mock-added-ingredient', suggested: ['var-1', 'var-2'] })
+    })
+
+    it('shall safely handle malformed OpenAI JSON response', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve('not-json'))
+
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: 'mockIngredient' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Error with parsing response' })
+    })
+
+    it('shall return suggested as [] when possibleVariations is missing', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve('```json\n{"isValid": false}\n```'))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
+        );
+
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: 'mockIngredient' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Invalid', suggested: [] })
+    })
+
+    it('shall return suggested as [] when possibleVariations is not an array', async () => {
+        getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        validateIngredientSpy.mockImplementationOnce(() => Promise.resolve(JSON.stringify({
+            isValid: false,
+            possibleVariations: 'bad-data'
+        })))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
+        );
+
+        const { req, res } = mockRequestResponse('POST')
+        const updatedreq: any = { ...req, body: { ingredientName: 'mockIngredient' } }
+        await validateIngredient(updatedreq, res)
+        expect(res.statusCode).toBe(200)
+        expect(res._getJSONData()).toEqual({ message: 'Invalid', suggested: [] })
     })
 
     it('will respond with error if POST call is rejected', async () => {

--- a/tests/pages/api/validate-ingredient.test.ts
+++ b/tests/pages/api/validate-ingredient.test.ts
@@ -74,6 +74,9 @@ describe('/api/validate-ingredient', () => {
 
     it('shall respond with error message if openai fails to validate request', async () => {
         getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
+        );
 
         const { req, res } = mockRequestResponse('POST')
         const updatedreq: any = {
@@ -149,6 +152,7 @@ describe('/api/validate-ingredient', () => {
         await validateIngredient(updatedreq, res)
         expect(res.statusCode).toBe(200)
         expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+        expect(validateIngredientSpy).not.toHaveBeenCalled()
     })
 
     it('shall detect case-insensitive existing ingredients', async () => {
@@ -165,6 +169,7 @@ describe('/api/validate-ingredient', () => {
         await validateIngredient(updatedreq, res)
         expect(res.statusCode).toBe(200)
         expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+        expect(validateIngredientSpy).not.toHaveBeenCalled()
     })
 
     it('shall detect singular and plural duplicate ingredients', async () => {
@@ -181,6 +186,7 @@ describe('/api/validate-ingredient', () => {
         await validateIngredient(updatedreq, res)
         expect(res.statusCode).toBe(200)
         expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+        expect(validateIngredientSpy).not.toHaveBeenCalled()
     })
 
     it('shall detect duplicates when incoming ingredient has padded whitespace', async () => {
@@ -197,6 +203,7 @@ describe('/api/validate-ingredient', () => {
         await validateIngredient(updatedreq, res)
         expect(res.statusCode).toBe(200)
         expect(res._getJSONData()).toEqual({ message: 'Error: This ingredient already exists' })
+        expect(validateIngredientSpy).not.toHaveBeenCalled()
     })
 
     it('shall add the requested ingredient if valid and does not exist in the db', async () => {
@@ -229,6 +236,9 @@ describe('/api/validate-ingredient', () => {
     it('shall safely handle malformed OpenAI JSON response', async () => {
         getServerSessionSpy.mockImplementationOnce(() => Promise.resolve(getServerSessionStub))
         validateIngredientSpy.mockImplementationOnce(() => Promise.resolve('not-json'))
+        Ingredient.find = jest.fn().mockImplementation(
+            () => Promise.resolve([]),
+        );
 
         const { req, res } = mockRequestResponse('POST')
         const updatedreq: any = { ...req, body: { ingredientName: 'mockIngredient' } }


### PR DESCRIPTION
### Motivation
- The ingredient validation API trusted UI-level checks and raw AI output, allowing whitespace/overlength input, malformed OpenAI JSON to cause 500s, and near-duplicate ingredient records to be created.

### Description
- Add backend normalization and validation for `ingredientName`: trim input, reject missing/whitespace-only values, enforce a 20-character max, and use the trimmed value downstream.
- Make OpenAI parsing robust by stripping optional code fences, guarding `JSON.parse` in `parseValidationResponse`, ensuring `isValid` is boolean, and normalizing `possibleVariations` to a string array with a `[]` fallback.
- Harden duplicate detection by fetching existing ingredient names and comparing normalized forms (case- and trim-insensitive) and singular/plural equivalence using `pluralize.singular(...)` so no new near-duplicates are inserted.
- Update `tests/pages/api/validate-ingredient.test.ts` to reflect the new flow and add tests covering whitespace/over-length rejections, case/plural/whitespace duplicate detection, malformed OpenAI JSON handling, and `possibleVariations` fallbacks.

### Testing
- Ran `npm test -- validate-ingredient --watchAll=false` and the updated Jest suite passed (`tests/pages/api/validate-ingredient.test.ts` — 16 tests passed).
- Ran `npm run compileTS` and TypeScript checks completed successfully with no errors.
- All new and updated tests in `tests/pages/api/validate-ingredient.test.ts` passed locally.
- Closes #50

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62e91c228832b8ca797d0e06aa4ea)